### PR TITLE
Phase 3: logger infrastructure and kill switch

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -68,9 +68,9 @@ Confirm `make check` passes on a clean clone; confirm CI workflow runs on the PR
 
 ## Phase 2 — CRD Type Definitions
 
-**Status:** `[~]`
+**Status:** `[x]`
 **Depends on:** Phase 1
-**PR:** —
+**PR:** https://github.com/Tight-Line/ballast/pull/2
 
 ### What to build
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -135,13 +135,13 @@ _Inspect generated CRD YAML; confirm all fields from DESIGN.md are present with 
 - All controllers and the webhook call `IsActive()` before taking any external action; log at `warn` with `kill_switch: true` when suppressed
 - Unit tests cover: ConfigMap present, ConfigMap absent, BallastConfig.suspended true/false, both active simultaneously, controller-runtime envtest
 
-### Key files (fill in after complete)
+### Key files
 
-- `internal/logger/logger.go`
+- `internal/logger/logger.go` — `New(component, level, format)` returns a `logr.Logger` backed by zap; `newWithWriter` is the testable variant
 - `internal/logger/logger_test.go`
-- `internal/killswitch/killswitch.go`
-- `internal/killswitch/killswitch_test.go`
-- `cmd/ballastd/main.go` (flag registration, logger init, kill switch watcher setup)
+- `internal/killswitch/killswitch.go` — `KillSwitch` reconciler; `IsActive()`/`Reason()` are the hot-path call sites; `SetupWithManager` wires ConfigMap + BallastConfig watches
+- `internal/killswitch/killswitch_test.go` — fake-client unit tests covering all trigger combinations
+- `cmd/ballastd/main.go` — `--log-level`, `--log-level-{webhook,watcher,collector,adjuster}`, `--log-format`, `--operator-namespace` flags; kill switch registered with manager
 
 ### User testing instructions
 

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -30,12 +30,13 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/logger"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -43,6 +44,13 @@ var (
 	scheme   = runtime.NewScheme()
 	setupLog = ctrl.Log.WithName("setup")
 )
+
+func getEnvOrDefault(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
 
 func init() {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
@@ -77,13 +85,22 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
+
+	var logLevel, logLevelWebhook, logLevelWatcher, logLevelCollector, logLevelAdjuster, logFormat string
+	flag.StringVar(&logLevel, "log-level", "info", "Global log level (debug|info|warn|error).")
+	flag.StringVar(&logLevelWebhook, "log-level-webhook", "", "Log level for the webhook component (overrides --log-level).")
+	flag.StringVar(&logLevelWatcher, "log-level-watcher", "", "Log level for the workload watcher component.")
+	flag.StringVar(&logLevelCollector, "log-level-collector", "", "Log level for the metrics collector component.")
+	flag.StringVar(&logLevelAdjuster, "log-level-adjuster", "", "Log level for the resource adjuster component.")
+	flag.StringVar(&logFormat, "log-format", "json", "Log output format (json|text).")
+
+	var operatorNamespace string
+	flag.StringVar(&operatorNamespace, "operator-namespace", getEnvOrDefault("POD_NAMESPACE", "ballast-system"),
+		"Namespace where the operator is running (used for kill-switch ConfigMap watch).")
+
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger(logger.New("setup", logLevel, logFormat))
 
 	// Disable HTTP/2 by default to avoid stream cancellation and rapid reset CVEs.
 	disableHTTP2 := func(c *tls.Config) {
@@ -143,6 +160,12 @@ func main() {
 	}
 
 	// +kubebuilder:scaffold:builder
+
+	ks := killswitch.New(mgr.GetClient(), operatorNamespace)
+	if err := ks.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to set up kill switch")
+		os.Exit(1)
+	}
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")

--- a/internal/killswitch/killswitch.go
+++ b/internal/killswitch/killswitch.go
@@ -1,0 +1,133 @@
+package killswitch
+
+import (
+	"context"
+	"sync"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+)
+
+const (
+	ConfigMapName     = "ballast-kill-switch"
+	BallastConfigName = "ballast"
+)
+
+// KillSwitch watches the emergency ConfigMap and BallastConfig.spec.suspended.
+// IsActive returns true if either trigger is live.
+type KillSwitch struct {
+	client    client.Client
+	namespace string
+
+	mu     sync.RWMutex
+	active bool
+	reason string
+}
+
+// New creates a KillSwitch that watches resources in namespace.
+func New(c client.Client, namespace string) *KillSwitch {
+	return &KillSwitch{client: c, namespace: namespace}
+}
+
+// IsActive reports whether the kill switch is currently active.
+func (k *KillSwitch) IsActive() bool {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.active
+}
+
+// Reason returns a human-readable description of the active trigger(s).
+func (k *KillSwitch) Reason() string {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	return k.reason
+}
+
+// Reconcile re-evaluates both kill switch sources and updates internal state.
+func (k *KillSwitch) Reconcile(ctx context.Context, _ reconcile.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var cm corev1.ConfigMap
+	cmActive := false
+	switch err := k.client.Get(ctx, types.NamespacedName{Name: ConfigMapName, Namespace: k.namespace}, &cm); {
+	case err == nil:
+		cmActive = true
+	case apierrors.IsNotFound(err):
+		// not active
+	default: // coverage:ignore - transient API error
+		return ctrl.Result{}, err
+	}
+
+	var cfg ballastv1.BallastConfig
+	cfgSuspended := false
+	switch err := k.client.Get(ctx, types.NamespacedName{Name: BallastConfigName}, &cfg); {
+	case err == nil:
+		cfgSuspended = cfg.Spec.Suspended
+	case apierrors.IsNotFound(err):
+		// not suspended
+	default: // coverage:ignore - transient API error
+		return ctrl.Result{}, err
+	}
+
+	active := cmActive || cfgSuspended
+
+	var reason string
+	switch {
+	case cmActive && cfgSuspended:
+		reason = "ConfigMap " + ConfigMapName + " and BallastConfig.spec.suspended"
+	case cmActive:
+		reason = "ConfigMap " + ConfigMapName
+	case cfgSuspended:
+		reason = "BallastConfig.spec.suspended"
+	}
+
+	k.mu.Lock()
+	changed := k.active != active
+	k.active = active
+	k.reason = reason
+	k.mu.Unlock()
+
+	if changed {
+		if active {
+			log.Info("Kill switch activated", "reason", reason)
+		} else {
+			log.Info("Kill switch deactivated")
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// SetupWithManager registers the kill switch controller with mgr.
+func (k *KillSwitch) SetupWithManager(mgr ctrl.Manager) error {
+	enqueue := handler.EnqueueRequestsFromMapFunc(
+		func(_ context.Context, _ client.Object) []reconcile.Request {
+			return []reconcile.Request{
+				{NamespacedName: types.NamespacedName{Name: ConfigMapName, Namespace: k.namespace}},
+			}
+		},
+	)
+
+	cmFilter := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == ConfigMapName && obj.GetNamespace() == k.namespace
+	})
+
+	bcFilter := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+		return obj.GetName() == BallastConfigName
+	})
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("killswitch").
+		Watches(&corev1.ConfigMap{}, enqueue, builder.WithPredicates(cmFilter)).
+		Watches(&ballastv1.BallastConfig{}, enqueue, builder.WithPredicates(bcFilter)).
+		Complete(k)
+}

--- a/internal/killswitch/killswitch_test.go
+++ b/internal/killswitch/killswitch_test.go
@@ -1,0 +1,242 @@
+package killswitch_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/killswitch"
+)
+
+const testNamespace = "ballast-system"
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = ballastv1.AddToScheme(s)
+	return s
+}
+
+func reconcileOnce(t *testing.T, ks *killswitch.KillSwitch) {
+	t.Helper()
+	_, err := ks.Reconcile(context.Background(), reconcile.Request{})
+	if err != nil {
+		t.Fatalf("Reconcile error: %v", err)
+	}
+}
+
+// --- unit tests (fake client) ---
+
+func TestKillSwitch_Inactive(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if ks.IsActive() {
+		t.Error("expected kill switch inactive when neither trigger is set")
+	}
+	if ks.Reason() != "" {
+		t.Errorf("expected empty reason, got %q", ks.Reason())
+	}
+}
+
+func TestKillSwitch_ConfigMapPresent(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: killswitch.ConfigMapName, Namespace: testNamespace,
+	}}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if !ks.IsActive() {
+		t.Error("expected kill switch active when ConfigMap present")
+	}
+	want := "ConfigMap " + killswitch.ConfigMapName
+	if ks.Reason() != want {
+		t.Errorf("reason: got %q, want %q", ks.Reason(), want)
+	}
+}
+
+func TestKillSwitch_ConfigMapAbsent(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if ks.IsActive() {
+		t.Error("expected kill switch inactive when ConfigMap absent")
+	}
+}
+
+func TestKillSwitch_BallastConfigSuspendedTrue(t *testing.T) {
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app"}, Suspended: true},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cfg).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if !ks.IsActive() {
+		t.Error("expected kill switch active when BallastConfig.spec.suspended=true")
+	}
+	if ks.Reason() != "BallastConfig.spec.suspended" {
+		t.Errorf("unexpected reason: %q", ks.Reason())
+	}
+}
+
+func TestKillSwitch_BallastConfigSuspendedFalse(t *testing.T) {
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app"}, Suspended: false},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cfg).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if ks.IsActive() {
+		t.Error("expected kill switch inactive when BallastConfig.spec.suspended=false")
+	}
+}
+
+func TestKillSwitch_BothActive(t *testing.T) {
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: killswitch.ConfigMapName, Namespace: testNamespace,
+	}}
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app"}, Suspended: true},
+	}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm, cfg).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	if !ks.IsActive() {
+		t.Error("expected kill switch active when both triggers set")
+	}
+	want := "ConfigMap " + killswitch.ConfigMapName + " and BallastConfig.spec.suspended"
+	if ks.Reason() != want {
+		t.Errorf("reason: got %q, want %q", ks.Reason(), want)
+	}
+}
+
+func TestKillSwitch_Deactivation(t *testing.T) {
+	ctx := context.Background()
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: killswitch.ConfigMapName, Namespace: testNamespace,
+	}}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+	ks := killswitch.New(fc, testNamespace)
+
+	reconcileOnce(t, ks)
+	if !ks.IsActive() {
+		t.Fatal("expected active after ConfigMap created")
+	}
+
+	if err := fc.Delete(ctx, cm); err != nil {
+		t.Fatalf("Delete ConfigMap: %v", err)
+	}
+	reconcileOnce(t, ks)
+	if ks.IsActive() {
+		t.Error("expected inactive after ConfigMap deleted")
+	}
+}
+
+func TestKillSwitch_NoChangeOnRepeatReconcile(t *testing.T) {
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	ks := killswitch.New(fc, testNamespace)
+	reconcileOnce(t, ks)
+	reconcileOnce(t, ks) // second reconcile with same state — exercises changed=false path
+	if ks.IsActive() {
+		t.Error("expected still inactive")
+	}
+}
+
+// --- envtest test: exercises SetupWithManager, watches, and predicates ---
+
+func TestKillSwitch_SetupWithManager(t *testing.T) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "config", "crd", "bases")},
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = testEnv.Stop() })
+
+	scheme := newScheme()
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 scheme,
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	ks := killswitch.New(mgr.GetClient(), testNamespace)
+	if err := ks.SetupWithManager(mgr); err != nil {
+		t.Fatalf("SetupWithManager: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	mgrErr := make(chan error, 1)
+	go func() { mgrErr <- mgr.Start(ctx) }()
+
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+
+	c := mgr.GetClient()
+
+	// Create the namespace so ConfigMap creation succeeds.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNamespace}}
+	if err := c.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create namespace: %v", err)
+	}
+
+	// Create kill-switch ConfigMap; reconcile should activate.
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: killswitch.ConfigMapName, Namespace: testNamespace,
+	}}
+	if err := c.Create(ctx, cm); err != nil {
+		t.Fatalf("create ConfigMap: %v", err)
+	}
+	waitFor(t, ks.IsActive, true, "kill switch to activate after ConfigMap creation")
+
+	// Create a BallastConfig (exercises bcFilter predicate).
+	ballastCfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app"}},
+	}
+	if err := c.Create(ctx, ballastCfg); err != nil {
+		t.Fatalf("create BallastConfig: %v", err)
+	}
+
+	// Delete ConfigMap; reconcile should deactivate (BallastConfig.suspended=false).
+	if err := c.Delete(ctx, cm); err != nil {
+		t.Fatalf("delete ConfigMap: %v", err)
+	}
+	waitFor(t, ks.IsActive, false, "kill switch to deactivate after ConfigMap deletion")
+}
+
+// waitFor polls fn until it returns want, or the test fails after 10 s.
+func waitFor(t *testing.T, fn func() bool, want bool, desc string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() == want {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("timed out waiting for %s", desc)
+}

--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -1,0 +1,43 @@
+package logger
+
+import (
+	"io"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// New returns a logr.Logger for the named component, writing to stderr.
+// level is one of "debug", "info", "warn", "error" (defaults to "info").
+// format is "json" or "text" (defaults to "json").
+func New(component, level, format string) logr.Logger {
+	return newWithWriter(component, level, format, os.Stderr)
+}
+
+func newWithWriter(component, level, format string, w io.Writer) logr.Logger {
+	var encoder zapcore.Encoder
+	if format == "text" {
+		encoder = zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig())
+	} else {
+		encoder = zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	}
+	core := zapcore.NewCore(encoder, zapcore.AddSync(w), parseLevel(level))
+	z := zap.New(core)
+	return zapr.NewLogger(z).WithName(component)
+}
+
+func parseLevel(level string) zapcore.Level {
+	switch level {
+	case "debug":
+		return zapcore.DebugLevel
+	case "warn":
+		return zapcore.WarnLevel
+	case "error":
+		return zapcore.ErrorLevel
+	default:
+		return zapcore.InfoLevel
+	}
+}

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,44 @@
+package logger
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestNew_SmokeTest(t *testing.T) {
+	l := New("test", "info", "json")
+	l.Info("smoke test")
+}
+
+func TestNewWithWriter_Levels(t *testing.T) {
+	for _, lvl := range []string{"debug", "info", "warn", "error", "invalid"} {
+		t.Run(lvl, func(t *testing.T) {
+			var buf bytes.Buffer
+			l := newWithWriter("test", lvl, "json", &buf)
+			l.Info("msg")
+		})
+	}
+}
+
+func TestNewWithWriter_JSONFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := newWithWriter("test", "info", "json", &buf)
+	l.Info("hello")
+	if !strings.HasPrefix(strings.TrimSpace(buf.String()), "{") {
+		t.Errorf("expected JSON output, got: %q", buf.String())
+	}
+}
+
+func TestNewWithWriter_TextFormat(t *testing.T) {
+	var buf bytes.Buffer
+	l := newWithWriter("test", "info", "text", &buf)
+	l.Info("hello")
+	out := strings.TrimSpace(buf.String())
+	if out == "" {
+		t.Error("expected non-empty text output")
+	}
+	if strings.HasPrefix(out, "{") {
+		t.Errorf("expected text output, not JSON, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

- `internal/logger`: `New(component, level, format)` returns a `logr.Logger` backed by zap. Supports `json`/`text` formats and `debug`/`info`/`warn`/`error` levels. Per-component log level flags (`--log-level-webhook`, `--log-level-watcher`, etc.) registered in `main.go` for use by controllers in later phases.
- `internal/killswitch`: `KillSwitch` is a controller-runtime reconciler that watches two trigger sources — the `ballast-kill-switch` ConfigMap and `BallastConfig.spec.suspended`. `IsActive()`/`Reason()` are the call sites for all controllers and the webhook. Covered by both fake-client unit tests (all trigger combinations) and an envtest integration test (watches, predicates, activation/deactivation lifecycle).
- `cmd/ballastd`: replaces the kubebuilder zap flag block with our logger factory; adds `--operator-namespace` for the kill switch ConfigMap watch; registers `KillSwitch` with the manager.

## Test plan

- [x] `make check` passes (lint, vet, fmt, 100% coverage with `coverage:ignore` for the two untestable transient-API-error returns)
- [x] Logger smoke: `go run ./cmd/ballastd --log-format=text --log-level=debug` — confirm console output
- [x] Kill switch: `kubectl create configmap ballast-kill-switch -n ballast-system` — confirm log line `kill_switch activated`