### PR TITLE
Fix implementation status in README; add CLAUDE.md sync reminder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Ballast — Claude Code Instructions
+
+## Status sync at end of each PR
+
+Before opening or finalizing a PR, keep these two files consistent with each other and with the actual implementation status:
+
+- `IMPLEMENTATION_PLAN.md` — update the phase `Status:` line to `[x]` (complete) or `[~]` (PR open) and fill in the PR link
+- `README.md` — update the Implementation Status table to match
+
+Rule: if all features of a phase are done and a PR is open, mark the phase complete (`[x]` / "Complete"). PRs are only opened once the feature set is finished.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Progressive modes (`autoresize`, `automagic`) start in measure-only mode and aut
 
 | Phase | What | Status |
 |---|---|---|
-| 1 | Repository scaffold, kubebuilder init, CI/CD | In progress |
-| 2 | CRD type definitions | Not started |
-| 3 | Logger infrastructure and kill switch | Not started |
+| 1 | Repository scaffold, kubebuilder init, CI/CD | Complete |
+| 2 | CRD type definitions | Complete |
+| 3 | Logger infrastructure and kill switch | Complete |
 | 4 | Policy resolution | Not started |
 | 5 | Redis/Valkey client layer | Not started |
 | 6 | Plugin interface and `kubernetesMetrics` plugin | Not started |


### PR DESCRIPTION
## Summary

- README implementation status table was stale (Phase 1 shown as in-progress, Phases 2-3 shown as not started). All three have merged PRs and are complete.
- Added `CLAUDE.md` with a rule to keep `README.md` and `IMPLEMENTATION_PLAN.md` in sync with each other at the close of every PR. Includes the "open PR = complete phase" rule.

## Test plan

- [x] Verify README status table shows Phases 1-3 as Complete
- [x] Verify CLAUDE.md is present and contains the sync rule