### PR TITLE
Phase 8: MetricsCollector controller

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -324,9 +324,9 @@ _Deploy to a test cluster with a pod carrying the `measure` annotation. Confirm 
 
 ## Phase 8 — MetricsCollector Controller
 
-**Status:** `[ ]`
+**Status:** `[x]`
 **Depends on:** Phases 3, 4, 5, 6, 7
-**PR:** —
+**PR:** TBD
 
 ### What to build
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -326,7 +326,7 @@ _Deploy to a test cluster with a pod carrying the `measure` annotation. Confirm 
 
 **Status:** `[x]`
 **Depends on:** Phases 3, 4, 5, 6, 7
-**PR:** TBD
+**PR:** https://github.com/Tight-Line/ballast/pull/11
 
 ### What to build
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test test-coverage test-coverage-check lint lint-fix lint-config fmt vet tidy tools \
+.PHONY: build clean test test-coverage test-coverage-check lint lint-fix lint-config fmt vet tidy tools \
         setup-hooks docker check \
         manifests generate install uninstall deploy undeploy \
         setup-envtest setup-test-e2e test-e2e cleanup-test-e2e \
@@ -62,6 +62,10 @@ setup-hooks: ## Install git pre-commit hook.
 
 build: manifests generate fmt vet ## Build the ballastd binary.
 	go build -o bin/ballastd ./cmd/ballastd
+
+clean: ## Remove build artifacts and coverage files; clear the Go test cache.
+	go clean -testcache
+	rm -f bin/ballastd coverage.out coverage.filtered.out coverage.html
 
 run: manifests generate fmt vet ## Run ballastd from your host (uses current kubeconfig).
 	go run ./cmd/ballastd

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Progressive modes (`autoresize`, `automagic`) start in measure-only mode and aut
 | 5 | Redis/Valkey client layer | Complete |
 | 6 | Plugin interface and `kubernetesMetrics` plugin | Complete |
 | 7 | WorkloadWatcher controller | Complete |
-| 8 | MetricsCollector controller | Not started |
+| 8 | MetricsCollector controller | Complete |
 | 9 | Admission webhook | Not started |
 | 10 | ResourceAdjuster controller | Not started |
 | 11 | Helm chart | Not started |

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -25,8 +25,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/controller/metricscollector"
 	"github.com/tight-line/ballast/internal/controller/workloadwatcher"
+	"github.com/tight-line/ballast/internal/killswitch"
 	"github.com/tight-line/ballast/internal/logger"
+	"github.com/tight-line/ballast/internal/store"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -75,6 +78,10 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+
+	var dryRunMeasure bool
+	flag.BoolVar(&dryRunMeasure, "dry-run-measure", false,
+		"If set, metrics are computed but not written to Redis and WorkloadProfile status is not updated.")
 
 	var logLevel, logLevelWebhook, logLevelWatcher, logLevelCollector, logLevelAdjuster, logFormat string
 	flag.StringVar(&logLevel, "log-level", "info", "Global log level (debug|info|warn|error).")
@@ -155,8 +162,25 @@ func main() {
 
 	// +kubebuilder:scaffold:builder
 
-	if err := workloadwatcher.Setup(mgr, operatorNamespace, redisURL); err != nil {
-		setupLog.Error(err, "Failed to set up controllers")
+	storeClient, err := store.NewClient(redisURL)
+	if err != nil {
+		setupLog.Error(err, "Failed to create Redis client")
+		os.Exit(1)
+	}
+
+	ks := killswitch.New(mgr.GetClient(), operatorNamespace)
+	if err := ks.SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to set up kill switch")
+		os.Exit(1)
+	}
+
+	if err := workloadwatcher.New(mgr.GetClient(), ks, storeClient).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "Failed to set up workloadwatcher controller")
+		os.Exit(1)
+	}
+
+	if err := metricscollector.Setup(mgr, ks, storeClient, dryRunMeasure); err != nil {
+		setupLog.Error(err, "Failed to set up metricscollector controller")
 		os.Exit(1)
 	}
 

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -9,6 +9,8 @@ package metricscollector
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"sort"
 	"strconv"
 	"time"
@@ -405,9 +407,7 @@ func (r *Reconciler) buildContainerProfile(
 		if cp.Recommendations == nil {
 			cp.Recommendations = make(map[string]ballastv1.ResourceRecommendation)
 		}
-		for k, v := range recs {
-			cp.Recommendations[k] = v
-		}
+		maps.Copy(cp.Recommendations, recs)
 	}
 
 	return cp, allReady
@@ -434,7 +434,7 @@ func (r *Reconciler) processResourceStats(
 	metricsForResource []ballastv1.MetricConfig,
 	policySpec ballastv1.ClusterResourcePolicySpec,
 	retentionStartMs, nowMs int64,
-) (ballastv1.ContainerUsageStats, map[string]ballastv1.ResourceRecommendation, bool, error) {
+) (containerStats ballastv1.ContainerUsageStats, resourceRecs map[string]ballastv1.ResourceRecommendation, meetsReadiness bool, err error) {
 	key := store.MetricKey(tupleHash, containerName, resourceName)
 
 	svs, err := store.QueryWindow(ctx, r.storeClient, key, retentionStartMs, nowMs)
@@ -517,7 +517,7 @@ func parseValues(svs []store.ScoredValue) []int64 {
 			values = append(values, v)
 		}
 	}
-	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	slices.Sort(values)
 	return values
 }
 
@@ -623,10 +623,8 @@ func mergeObserved(dst, src map[string]map[string]struct{}) {
 }
 
 func appendUnique(slice []string, s string) []string {
-	for _, existing := range slice {
-		if existing == s {
-			return slice
-		}
+	if slices.Contains(slice, s) {
+		return slice
 	}
 	return append(slice, s)
 }

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -1,0 +1,648 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package metricscollector
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/plugin"
+	"github.com/tight-line/ballast/internal/policy"
+	"github.com/tight-line/ballast/internal/stats"
+	"github.com/tight-line/ballast/internal/store"
+)
+
+const (
+	defaultPollInterval    = 60 * time.Second
+	defaultRetentionWindow = 168 * time.Hour
+)
+
+// Reconciler collects metrics for each WorkloadProfile and updates its status.
+type Reconciler struct {
+	client        client.Client
+	storeClient   store.Client
+	ks            *killswitch.KillSwitch
+	resolver      *policy.Resolver
+	dryRunMeasure bool
+	// PluginGet is the registry lookup. Defaults to plugin.Get; overridable in tests
+	// without touching global plugin registry state.
+	PluginGet func(string) (plugin.MetricsPlugin, bool)
+}
+
+// New creates a Reconciler with the given dependencies.
+func New(c client.Client, sc store.Client, ks *killswitch.KillSwitch, dryRunMeasure bool) *Reconciler {
+	return &Reconciler{
+		client:        c,
+		storeClient:   sc,
+		ks:            ks,
+		resolver:      policy.NewResolver(c, ctrl.Log.WithName("metricscollector")),
+		dryRunMeasure: dryRunMeasure,
+		PluginGet:     plugin.Get,
+	}
+}
+
+// Setup wires a Reconciler into a running manager using a pre-registered KillSwitch.
+// The KillSwitch must already be registered with the same manager (e.g. by workloadwatcher.Setup)
+// so it is not double-registered.
+func Setup(mgr ctrl.Manager, ks *killswitch.KillSwitch, sc store.Client, dryRunMeasure bool) error {
+	return New(mgr.GetClient(), sc, ks, dryRunMeasure).SetupWithManager(mgr)
+}
+
+// SetupWithManager registers the Reconciler with mgr.
+func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("metricscollector").
+		For(&ballastv1.WorkloadProfile{}).
+		Complete(r)
+}
+
+// Reconcile is the main entry point for a WorkloadProfile reconcile cycle.
+//
+// Steps (in order):
+//  1. Load the WorkloadProfile — not-found is silently ignored; transient errors requeue.
+//  2. Load BallastConfig to get the retention window — not-found requeues after the default
+//     interval; parse errors fall back to the 7-day default.
+//  3. Resolve the matching policy — no match requeues after the default interval.
+//  4. Load MetricsSources referenced by the policy to determine poll interval and plugins.
+//  5. If the kill switch is active, log at warn and requeue without collecting data.
+//  6. Call collectAllSamples to fetch from each plugin and write to Redis
+//     (skipped per-sample when --dry-run-measure is set).
+//  7. Build container profiles: query Redis, compute stats, evaluate readiness, build
+//     recommendations for each (container, resource) pair.
+//  8. If --dry-run-measure, log what would be written and return without updating status.
+//  9. Patch WorkloadProfile status with updated container profiles and meetsThreshold.
+//
+// The return value always sets RequeueAfter to the minimum poll interval across all sources.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := ctrl.LoggerFrom(ctx)
+
+	var profile ballastv1.WorkloadProfile
+	if err := r.client.Get(ctx, req.NamespacedName, &profile); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err // coverage:ignore - transient API error
+	}
+
+	var cfg ballastv1.BallastConfig
+	if err := r.client.Get(ctx, types.NamespacedName{Name: killswitch.BallastConfigName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{RequeueAfter: defaultPollInterval}, nil
+		}
+		return ctrl.Result{}, err // coverage:ignore - transient API error
+	}
+
+	retentionWindow := parseRetentionWindow(cfg.Spec.RetentionWindow)
+
+	resolved, err := r.resolver.Resolve(ctx, policy.Input{Labels: profile.Status.TupleLabels})
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if resolved == nil {
+		log.Info("no policy matches profile, skipping", "profile", profile.Name)
+		return ctrl.Result{RequeueAfter: defaultPollInterval}, nil
+	}
+
+	sources, pollInterval := r.loadSources(ctx, resolved.Spec.Metrics)
+
+	if r.ks.IsActive() {
+		log.Info("kill switch active, skipping metrics collection",
+			"kill_switch", true, "kill_switch_reason", r.ks.Reason(), "profile", profile.Name)
+		return ctrl.Result{RequeueAfter: pollInterval}, nil
+	}
+
+	now := time.Now()
+	retentionStart := now.Add(-retentionWindow)
+	tupleHash := store.TupleHash(profile.Status.TupleLabels)
+
+	observed, err := r.collectAllSamples(ctx, tupleHash, profile.Status.TupleLabels, retentionStart, now, sources)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	resourcesInPolicy := policyResourceMap(resolved.Spec.Metrics)
+	containers := mergeContainerSets(observed, profile.Status.Containers, resourcesInPolicy)
+	containerProfiles, allReady := r.buildContainerProfiles(
+		ctx, tupleHash, containers, resourcesInPolicy, resolved.Spec,
+		retentionStart.UnixMilli(), now.UnixMilli())
+
+	if r.dryRunMeasure {
+		log.Info("dry-run: would update WorkloadProfile status",
+			"dry_run", true, "profile", profile.Name, "meetsThreshold", allReady)
+		return ctrl.Result{RequeueAfter: pollInterval}, nil
+	}
+
+	base := profile.DeepCopy()
+	profile.Status.Containers = containerProfiles
+	profile.Status.MeetsThreshold = allReady
+	if err := r.client.Status().Patch(ctx, &profile, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
+		return ctrl.Result{}, err
+	}
+
+	return ctrl.Result{RequeueAfter: pollInterval}, nil
+}
+
+// collectAllSamples iterates over each loaded MetricsSource, looks up its plugin,
+// calls FetchStats, and writes the resulting samples to Redis.
+//
+// Steps (in order):
+//  1. For each source, look up the plugin by type name. Unknown types are logged and skipped.
+//  2. Delegate to collectFromSource, which calls FetchStats and writes samples.
+//     FetchStats failures are non-fatal (logged and skipped per source).
+//     Redis write failures are fatal and return an error.
+//  3. Accumulate observed (container, resource) pairs across all sources.
+//
+// Returns the union of (container, resource) pairs seen across all sources.
+func (r *Reconciler) collectAllSamples(
+	ctx context.Context,
+	tupleHash string,
+	tupleLabels map[string]string,
+	retentionStart, now time.Time,
+	sources map[string]*ballastv1.MetricsSource,
+) (map[string]map[string]struct{}, error) {
+	log := ctrl.LoggerFrom(ctx)
+	observed := make(map[string]map[string]struct{})
+
+	for sourceName, ms := range sources {
+		p, ok := r.PluginGet(ms.Spec.Type)
+		if !ok {
+			log.Info("no plugin registered for source type, skipping",
+				"source", sourceName, "type", ms.Spec.Type)
+			continue
+		}
+
+		additional, err := r.collectFromSource(ctx, tupleHash, tupleLabels, retentionStart, now, sourceName, ms, p)
+		if err != nil {
+			return nil, err
+		}
+		mergeObserved(observed, additional)
+	}
+
+	return observed, nil
+}
+
+// collectFromSource calls FetchStats on a single plugin and writes the resulting samples to Redis.
+//
+// Steps (in order):
+//  1. Call FetchStats — on error, log at Error and return an empty result (non-fatal so other
+//     sources are still attempted).
+//  2. For each ContainerStats: record the (container, resource) pair as observed.
+//  3. If --dry-run-measure, log the sample and skip writing.
+//  4. Otherwise, delegate to writeSample (AddSample → ExpireOlderThan → EnforceReservoirCap).
+//     Redis write failures are fatal and propagate to the caller.
+//
+// Returns the (container, resource) pairs observed from this source's FetchStats results.
+func (r *Reconciler) collectFromSource(
+	ctx context.Context,
+	tupleHash string,
+	tupleLabels map[string]string,
+	retentionStart, now time.Time,
+	sourceName string,
+	ms *ballastv1.MetricsSource,
+	p plugin.MetricsPlugin,
+) (map[string]map[string]struct{}, error) {
+	log := ctrl.LoggerFrom(ctx)
+	observed := make(map[string]map[string]struct{})
+
+	samples, err := p.FetchStats(ctx,
+		plugin.WorkloadIdentity{Labels: tupleLabels},
+		plugin.TimeWindow{Start: retentionStart, End: now})
+	if err != nil {
+		log.Error(err, "FetchStats failed", "source", sourceName)
+		return observed, nil
+	}
+
+	for _, s := range samples {
+		markObserved(observed, s.ContainerName, s.Resource)
+
+		if r.dryRunMeasure {
+			log.Info("dry-run: would write sample",
+				"dry_run", true, "container", s.ContainerName,
+				"resource", s.Resource, "value", s.Value.String())
+			continue
+		}
+
+		if err := r.writeSample(ctx, tupleHash, retentionStart, ms, s); err != nil {
+			return nil, err
+		}
+	}
+
+	return observed, nil
+}
+
+// writeSample persists a single ContainerStats entry to Redis.
+// It runs three operations in order: AddSample, ExpireOlderThan, EnforceReservoirCap.
+// Any failure is returned immediately; all three are wrapped with context.
+func (r *Reconciler) writeSample(
+	ctx context.Context,
+	tupleHash string,
+	retentionStart time.Time,
+	ms *ballastv1.MetricsSource,
+	s plugin.ContainerStats,
+) error {
+	key := store.MetricKey(tupleHash, s.ContainerName, s.Resource)
+	valueStr := quantityToStoreValue(s.Resource, s.Value)
+
+	if err := store.AddSample(ctx, r.storeClient, key, s.Timestamp.UnixMilli(), valueStr); err != nil { // coverage:ignore - Redis error
+		return fmt.Errorf("adding sample for %s: %w", key, err)
+	}
+	if err := store.ExpireOlderThan(ctx, r.storeClient, key, retentionStart.UnixMilli()); err != nil { // coverage:ignore - Redis error
+		return fmt.Errorf("expiring samples for %s: %w", key, err)
+	}
+	if ms.Spec.Config.ReservoirSize > 0 {
+		if err := store.EnforceReservoirCap(ctx, r.storeClient, key, ms.Spec.Config.ReservoirSize); err != nil { // coverage:ignore - Redis error
+			return fmt.Errorf("enforcing reservoir cap for %s: %w", key, err)
+		}
+	}
+	return nil
+}
+
+// loadSources fetches the MetricsSource CRD for each unique source name referenced in the
+// policy metrics. It also computes the minimum poll interval across all loaded sources.
+//
+// Missing sources are logged at Warn (misconfigured policy reference); transient errors
+// are logged at Error. In either case the controller continues with any sources that did
+// load. Returns the loaded sources and the minimum poll interval found, falling back to
+// defaultPollInterval if no sources loaded successfully.
+func (r *Reconciler) loadSources(ctx context.Context, metrics []ballastv1.MetricConfig) (map[string]*ballastv1.MetricsSource, time.Duration) {
+	sources := make(map[string]*ballastv1.MetricsSource)
+	pollInterval := defaultPollInterval
+
+	for _, m := range metrics {
+		if _, seen := sources[m.Source]; seen {
+			continue
+		}
+		ms := r.tryLoadSource(ctx, m.Source)
+		if ms == nil {
+			continue
+		}
+		sources[m.Source] = ms
+		pollInterval = minPollInterval(ms, pollInterval)
+	}
+
+	return sources, pollInterval
+}
+
+// tryLoadSource attempts to load a MetricsSource by name.
+// Not-found is logged at Warn (misconfigured policy reference). Other errors are logged at Error.
+// Returns nil in either failure case.
+func (r *Reconciler) tryLoadSource(ctx context.Context, name string) *ballastv1.MetricsSource {
+	log := ctrl.LoggerFrom(ctx)
+	var ms ballastv1.MetricsSource
+	if err := r.client.Get(ctx, types.NamespacedName{Name: name}, &ms); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("MetricsSource not found; check policy configuration", "source", name)
+		} else {
+			log.Error(err, "failed to load MetricsSource", "source", name)
+		}
+		return nil
+	}
+	return &ms
+}
+
+// buildContainerProfiles builds a ContainerProfile for each tracked container by
+// querying Redis for each policy-referenced resource.
+//
+// Steps (in order):
+//  1. Return immediately (nil, false) if no containers are tracked.
+//  2. For each container (in sorted order), delegate to buildContainerProfile.
+//  3. If any container reports not-ready, allReady is set false.
+//
+// Returns the slice of profiles and a single meetsThreshold bool (true only when
+// at least one container was processed and all are ready).
+func (r *Reconciler) buildContainerProfiles(
+	ctx context.Context,
+	tupleHash string,
+	containers map[string][]string,
+	resourcesInPolicy map[string][]ballastv1.MetricConfig,
+	policySpec ballastv1.ClusterResourcePolicySpec,
+	retentionStartMs, nowMs int64,
+) ([]ballastv1.ContainerProfile, bool) {
+	if len(containers) == 0 {
+		return nil, false
+	}
+
+	allReady := true
+	var containerProfiles []ballastv1.ContainerProfile
+
+	for _, containerName := range sortedKeys(containers) {
+		cp, ready := r.buildContainerProfile(ctx, tupleHash, containerName,
+			containers[containerName], resourcesInPolicy, policySpec,
+			retentionStartMs, nowMs)
+		if !ready {
+			allReady = false
+		}
+		containerProfiles = append(containerProfiles, cp)
+	}
+
+	return containerProfiles, allReady && len(containerProfiles) > 0
+}
+
+// buildContainerProfile queries Redis for each policy-referenced resource of a single container,
+// computes its stats and recommendations, and assembles the ContainerProfile.
+//
+// Steps (in order):
+//  1. For each resource (sorted) that appears in the policy:
+//     a. Delegate to processResourceStats to query Redis and compute stats.
+//     b. On error: log at Error and mark this container not-ready; continue to the next resource.
+//     c. Append the returned ContainerUsageStats to the profile.
+//     d. If not ready: mark not-ready and skip recommendations.
+//     e. If ready: merge returned recommendations into the profile's Recommendations map.
+//  2. Return the assembled profile and whether all tracked resources were ready.
+func (r *Reconciler) buildContainerProfile(
+	ctx context.Context,
+	tupleHash, containerName string,
+	resources []string,
+	resourcesInPolicy map[string][]ballastv1.MetricConfig,
+	policySpec ballastv1.ClusterResourcePolicySpec,
+	retentionStartMs, nowMs int64,
+) (ballastv1.ContainerProfile, bool) {
+	log := ctrl.LoggerFrom(ctx)
+	cp := ballastv1.ContainerProfile{Name: containerName}
+	allReady := true
+
+	for _, resourceName := range sortedStringSlice(resources) {
+		metricsForResource := resourcesInPolicy[resourceName]
+		if len(metricsForResource) == 0 {
+			// Defensive guard: mergeContainerSets filters to policy resources, so this
+			// should not occur in practice.
+			log.Info("resource tracked but not found in policy map; skipping",
+				"container", containerName, "resource", resourceName)
+			continue
+		}
+
+		usageStats, recs, ready, err := r.processResourceStats(
+			ctx, tupleHash, containerName, resourceName, metricsForResource, policySpec, retentionStartMs, nowMs)
+		if err != nil {
+			log.Error(err, "processResourceStats failed",
+				"container", containerName, "resource", resourceName)
+			allReady = false
+			continue
+		}
+
+		cp.UsageStats = append(cp.UsageStats, usageStats)
+		if !ready {
+			allReady = false
+			continue
+		}
+
+		if cp.Recommendations == nil {
+			cp.Recommendations = make(map[string]ballastv1.ResourceRecommendation)
+		}
+		for k, v := range recs {
+			cp.Recommendations[k] = v
+		}
+	}
+
+	return cp, allReady
+}
+
+// processResourceStats queries Redis for a single (container, resource) key, computes
+// statistical aggregates, evaluates readiness against the policy, and computes
+// recommendations for all metric entries referencing this resource.
+//
+// Steps (in order):
+//  1. QueryWindow to retrieve all samples in the retention window.
+//     Redis errors are returned as fatal.
+//  2. Parse member strings to int64 and sort ascending for percentile computation.
+//  3. ComputeStats (p50/p95/p99/max/mean/stddev/cv).
+//  4. TimeRange to get the oldest and newest sample timestamps.
+//     Redis errors are returned as fatal.
+//  5. EvaluateReadiness against the policy readiness config.
+//  6. Build and return a ContainerUsageStats for the caller to append.
+//  7. If not ready: return (usageStats, nil recommendations, false, nil).
+//  8. If ready: computeAllRecommendations for all metric entries for this resource.
+func (r *Reconciler) processResourceStats(
+	ctx context.Context,
+	tupleHash, containerName, resourceName string,
+	metricsForResource []ballastv1.MetricConfig,
+	policySpec ballastv1.ClusterResourcePolicySpec,
+	retentionStartMs, nowMs int64,
+) (ballastv1.ContainerUsageStats, map[string]ballastv1.ResourceRecommendation, bool, error) {
+	key := store.MetricKey(tupleHash, containerName, resourceName)
+
+	svs, err := store.QueryWindow(ctx, r.storeClient, key, retentionStartMs, nowMs)
+	if err != nil { // coverage:ignore - Redis error
+		return ballastv1.ContainerUsageStats{}, nil, false, fmt.Errorf("QueryWindow %s: %w", key, err)
+	}
+
+	s := store.ComputeStats(parseValues(svs))
+
+	firstMs, lastMs, err := store.TimeRange(ctx, r.storeClient, key)
+	if err != nil { // coverage:ignore - Redis error
+		return ballastv1.ContainerUsageStats{}, nil, false, fmt.Errorf("TimeRange %s: %w", key, err)
+	}
+
+	ready := stats.EvaluateReadiness(s, firstMs, lastMs, policySpec.Readiness)
+	sourceName := metricsForResource[0].Source
+	usageStats := buildUsageStats(resourceName, sourceName, s, firstMs, lastMs)
+
+	if !ready {
+		return usageStats, nil, false, nil
+	}
+
+	recs := computeAllRecommendations(ctx, s, resourceName, metricsForResource)
+	return usageStats, recs, true, nil
+}
+
+// computeAllRecommendations computes a ResourceRecommendation for resourceName by
+// iterating over all metric entries for that resource. For each entry it calls
+// ComputeRecommendation and sets the Request or Limit field accordingly.
+// ComputeRecommendation failures (e.g. unknown aggregation in the policy) are logged at
+// Error and skipped — the recommendation for that field is simply left unset.
+func computeAllRecommendations(ctx context.Context, s store.Stats, resourceName string, metrics []ballastv1.MetricConfig) map[string]ballastv1.ResourceRecommendation {
+	log := ctrl.LoggerFrom(ctx)
+	recs := make(map[string]ballastv1.ResourceRecommendation)
+	rec := recs[resourceName]
+
+	for _, m := range metrics {
+		q, err := stats.ComputeRecommendation(s, m)
+		if err != nil {
+			log.Error(err, "ComputeRecommendation failed; check policy metric configuration",
+				"resource", resourceName, "field", m.Field, "aggregation", m.Aggregation)
+			continue
+		}
+		if m.Field == "request" {
+			rec.Request = q.String()
+		} else {
+			rec.Limit = q.String()
+		}
+	}
+
+	recs[resourceName] = rec
+	return recs
+}
+
+// buildUsageStats assembles a ContainerUsageStats from precomputed Stats and time range.
+func buildUsageStats(resourceName, sourceName string, s store.Stats, firstMs, lastMs int64) ballastv1.ContainerUsageStats {
+	now := metav1.Now()
+	return ballastv1.ContainerUsageStats{
+		Resource:    resourceName,
+		Source:      sourceName,
+		Samples:     int64(s.Count),
+		TimeSpan:    formatDuration(lastMs - firstMs),
+		P50:         formatResourceValue(resourceName, s.P50),
+		P95:         formatResourceValue(resourceName, s.P95),
+		P99:         formatResourceValue(resourceName, s.P99),
+		Mean:        formatResourceValue(resourceName, s.Mean),
+		StdDev:      formatResourceValue(resourceName, s.StdDev),
+		CV:          fmt.Sprintf("%.3f", s.CV),
+		LastUpdated: &now,
+	}
+}
+
+// parseValues converts a slice of ScoredValues to a sorted int64 slice for ComputeStats.
+// Unparseable members indicate corrupted Redis data and are discarded; this is a
+// defensive guard and should not occur under normal operation.
+func parseValues(svs []store.ScoredValue) []int64 {
+	values := make([]int64, 0, len(svs))
+	for _, sv := range svs {
+		if v, err := strconv.ParseInt(sv.Value, 10, 64); err == nil {
+			values = append(values, v)
+		}
+	}
+	sort.Slice(values, func(i, j int) bool { return values[i] < values[j] })
+	return values
+}
+
+// parseRetentionWindow parses a duration string, returning defaultRetentionWindow on error.
+func parseRetentionWindow(s string) time.Duration {
+	if d, err := time.ParseDuration(s); err == nil && d > 0 {
+		return d
+	}
+	return defaultRetentionWindow
+}
+
+// minPollInterval returns the smaller of current and the MetricsSource's configured pollInterval.
+// If the source's interval is unparseable or non-positive, current is returned unchanged.
+func minPollInterval(ms *ballastv1.MetricsSource, current time.Duration) time.Duration {
+	d, err := time.ParseDuration(ms.Spec.Config.PollInterval)
+	if err != nil || d <= 0 || d >= current {
+		return current
+	}
+	return d
+}
+
+// quantityToStoreValue converts a resource.Quantity to an integer string for Redis storage.
+// CPU is stored as millicores; everything else as bytes.
+func quantityToStoreValue(resourceName string, q resource.Quantity) string {
+	if resourceName == "cpu" {
+		return strconv.FormatInt(q.MilliValue(), 10)
+	}
+	return strconv.FormatInt(q.Value(), 10)
+}
+
+// formatResourceValue converts a raw float64 value to a display string.
+// CPU values are in millicores (rendered as "Xm"); memory/storage values are in bytes.
+func formatResourceValue(resourceName string, v float64) string {
+	if resourceName == "cpu" {
+		return resource.NewMilliQuantity(int64(v), resource.DecimalSI).String()
+	}
+	return resource.NewQuantity(int64(v), resource.BinarySI).String()
+}
+
+// formatDuration converts a millisecond span to a rounded-to-second duration string.
+// Returns "0s" for non-positive spans.
+func formatDuration(ms int64) string {
+	if ms <= 0 {
+		return "0s"
+	}
+	return (time.Duration(ms) * time.Millisecond).Round(time.Second).String()
+}
+
+// policyResourceMap returns a map from resource name to the list of MetricConfigs
+// that reference it. Used to look up which metrics to compute for a given resource.
+func policyResourceMap(metrics []ballastv1.MetricConfig) map[string][]ballastv1.MetricConfig {
+	result := make(map[string][]ballastv1.MetricConfig)
+	for _, m := range metrics {
+		result[m.Resource] = append(result[m.Resource], m)
+	}
+	return result
+}
+
+// mergeContainerSets returns a container→resources map combining containers from the current
+// FetchStats cycle with containers already present in the profile status. Only resources
+// referenced in the policy are included, ensuring stale resources don't accumulate.
+func mergeContainerSets(
+	current map[string]map[string]struct{},
+	existing []ballastv1.ContainerProfile,
+	resourcesInPolicy map[string][]ballastv1.MetricConfig,
+) map[string][]string {
+	result := make(map[string][]string)
+
+	for containerName, resourceSet := range current {
+		for resourceName := range resourceSet {
+			if _, inPolicy := resourcesInPolicy[resourceName]; inPolicy {
+				result[containerName] = appendUnique(result[containerName], resourceName)
+			}
+		}
+	}
+
+	for _, cp := range existing {
+		for _, us := range cp.UsageStats {
+			if _, inPolicy := resourcesInPolicy[us.Resource]; inPolicy {
+				result[cp.Name] = appendUnique(result[cp.Name], us.Resource)
+			}
+		}
+	}
+
+	return result
+}
+
+// markObserved records that (container, resource) was seen in a FetchStats cycle.
+func markObserved(observed map[string]map[string]struct{}, container, res string) {
+	if observed[container] == nil {
+		observed[container] = make(map[string]struct{})
+	}
+	observed[container][res] = struct{}{}
+}
+
+// mergeObserved adds all entries from src into dst.
+func mergeObserved(dst, src map[string]map[string]struct{}) {
+	for container, resources := range src {
+		for res := range resources {
+			markObserved(dst, container, res)
+		}
+	}
+}
+
+func appendUnique(slice []string, s string) []string {
+	for _, existing := range slice {
+		if existing == s {
+			return slice
+		}
+	}
+	return append(slice, s)
+}
+
+func sortedKeys(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedStringSlice(ss []string) []string {
+	sorted := make([]string, len(ss))
+	copy(sorted, ss)
+	sort.Strings(sorted)
+	return sorted
+}

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -113,7 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	retentionWindow := parseRetentionWindow(cfg.Spec.RetentionWindow)
 
 	resolved, err := r.resolver.Resolve(ctx, policy.Input{Labels: profile.Status.TupleLabels})
-	if err != nil {
+	if err != nil { // coverage:ignore - transient API error
 		return ctrl.Result{}, err
 	}
 	if resolved == nil {
@@ -134,7 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	tupleHash := store.TupleHash(profile.Status.TupleLabels)
 
 	observed, err := r.collectAllSamples(ctx, tupleHash, profile.Status.TupleLabels, retentionStart, now, sources)
-	if err != nil {
+	if err != nil { // coverage:ignore - Redis error
 		return ctrl.Result{}, err
 	}
 
@@ -190,7 +190,7 @@ func (r *Reconciler) collectAllSamples(
 		}
 
 		additional, err := r.collectFromSource(ctx, tupleHash, tupleLabels, retentionStart, now, sourceName, ms, p)
-		if err != nil {
+		if err != nil { // coverage:ignore - Redis error
 			return nil, err
 		}
 		mergeObserved(observed, additional)
@@ -240,7 +240,7 @@ func (r *Reconciler) collectFromSource(
 			continue
 		}
 
-		if err := r.writeSample(ctx, tupleHash, retentionStart, ms, s); err != nil {
+		if err := r.writeSample(ctx, tupleHash, retentionStart, ms, s); err != nil { // coverage:ignore - Redis error
 			return nil, err
 		}
 	}
@@ -310,7 +310,7 @@ func (r *Reconciler) tryLoadSource(ctx context.Context, name string) *ballastv1.
 	if err := r.client.Get(ctx, types.NamespacedName{Name: name}, &ms); err != nil {
 		if apierrors.IsNotFound(err) {
 			log.Info("MetricsSource not found; check policy configuration", "source", name)
-		} else {
+		} else { // coverage:ignore - transient API error
 			log.Error(err, "failed to load MetricsSource", "source", name)
 		}
 		return nil
@@ -381,9 +381,8 @@ func (r *Reconciler) buildContainerProfile(
 
 	for _, resourceName := range sortedStringSlice(resources) {
 		metricsForResource := resourcesInPolicy[resourceName]
-		if len(metricsForResource) == 0 {
-			// Defensive guard: mergeContainerSets filters to policy resources, so this
-			// should not occur in practice.
+		if len(metricsForResource) == 0 { // coverage:ignore - defensive guard, cannot occur in practice
+			// mergeContainerSets filters to policy resources, so this should never fire.
 			log.Info("resource tracked but not found in policy map; skipping",
 				"container", containerName, "resource", resourceName)
 			continue
@@ -391,7 +390,7 @@ func (r *Reconciler) buildContainerProfile(
 
 		usageStats, recs, ready, err := r.processResourceStats(
 			ctx, tupleHash, containerName, resourceName, metricsForResource, policySpec, retentionStartMs, nowMs)
-		if err != nil {
+		if err != nil { // coverage:ignore - Redis error
 			log.Error(err, "processResourceStats failed",
 				"container", containerName, "resource", resourceName)
 			allReady = false

--- a/internal/controller/metricscollector/controller_test.go
+++ b/internal/controller/metricscollector/controller_test.go
@@ -1,0 +1,586 @@
+package metricscollector_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/controller/metricscollector"
+	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/plugin"
+	"github.com/tight-line/ballast/internal/store"
+)
+
+// -- scheme & client helpers --
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = ballastv1.AddToScheme(s)
+	return s
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithObjects(objs...).
+		Build()
+}
+
+func inactiveKS(t *testing.T) *killswitch.KillSwitch {
+	t.Helper()
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	ks := killswitch.New(fc, "ballast-system")
+	if _, err := ks.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatalf("ks.Reconcile: %v", err)
+	}
+	return ks
+}
+
+func activeKS(t *testing.T) *killswitch.KillSwitch {
+	t.Helper()
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name:      killswitch.ConfigMapName,
+		Namespace: "ballast-system",
+	}}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+	ks := killswitch.New(fc, "ballast-system")
+	if _, err := ks.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatalf("ks.Reconcile: %v", err)
+	}
+	return ks
+}
+
+func newMiniredisClient(t *testing.T) (*miniredis.Miniredis, store.Client) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = rc.Close() })
+	return mr, rc
+}
+
+// mockPlugin is a test-only MetricsPlugin that returns pre-configured samples.
+type mockPlugin struct {
+	typeName string
+	samples  []plugin.ContainerStats
+	err      error
+}
+
+func (m *mockPlugin) Type() string { return m.typeName }
+func (m *mockPlugin) FetchStats(_ context.Context, _ plugin.WorkloadIdentity, _ plugin.TimeWindow) ([]plugin.ContainerStats, error) {
+	return m.samples, m.err
+}
+
+// newReconcilerWithPlugin wires a Reconciler with a fake client, miniredis, and a mock plugin.
+func newReconcilerWithPlugin(t *testing.T, fc client.Client, sc store.Client, ks *killswitch.KillSwitch, dryRun bool, p *mockPlugin) *metricscollector.Reconciler {
+	t.Helper()
+	r := metricscollector.New(fc, sc, ks, dryRun)
+	r.PluginGet = func(typeName string) (plugin.MetricsPlugin, bool) {
+		if p != nil && typeName == p.typeName {
+			return p, true
+		}
+		return nil, false
+	}
+	return r
+}
+
+func reconcileProfile(t *testing.T, r *metricscollector.Reconciler, name string) (ctrl.Result, error) {
+	t.Helper()
+	return r.Reconcile(context.Background(), reconcile.Request{
+		NamespacedName: types.NamespacedName{Name: name},
+	})
+}
+
+// -- fixture helpers --
+
+func defaultBallastConfig() *ballastv1.BallastConfig {
+	return &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec: ballastv1.BallastConfigSpec{
+			IdentityLabels:  []string{"app"},
+			OrphanTTL:       "168h",
+			RetentionWindow: "168h",
+		},
+	}
+}
+
+func defaultMetricsSource() *ballastv1.MetricsSource {
+	return &ballastv1.MetricsSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8s-metrics"},
+		Spec: ballastv1.MetricsSourceSpec{
+			Type: "kubernetesMetrics",
+			Config: ballastv1.MetricsSourceConfig{
+				PollInterval:  "60s",
+				ReservoirSize: 10000,
+			},
+		},
+	}
+}
+
+func defaultPolicy() *ballastv1.ClusterResourcePolicy {
+	return &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-defaults"},
+		Spec: ballastv1.ClusterResourcePolicySpec{
+			Metrics: []ballastv1.MetricConfig{
+				{Resource: "cpu", Field: "request", Source: "k8s-metrics", Aggregation: "p95", Headroom: "1.2"},
+				{Resource: "cpu", Field: "limit", Source: "k8s-metrics", Aggregation: "p99", Headroom: "1.25"},
+			},
+			Readiness: ballastv1.ReadinessConfig{
+				MinDataPoints: 2,
+				MinTimeSpan:   "1ms",
+				MaxCV:         "99.0",
+			},
+		},
+	}
+}
+
+func defaultProfile(tupleLabels map[string]string) *ballastv1.WorkloadProfile {
+	return &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		Status: ballastv1.WorkloadProfileStatus{
+			TupleLabels: tupleLabels,
+		},
+	}
+}
+
+func cpuSample(container string, milliCores int64, ts time.Time) plugin.ContainerStats {
+	return plugin.ContainerStats{
+		ContainerName: container,
+		Resource:      "cpu",
+		Value:         *resource.NewMilliQuantity(milliCores, resource.DecimalSI),
+		Timestamp:     ts,
+	}
+}
+
+// -- unit tests --
+
+func TestReconcile_ProfileNotFound(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig())
+	_, sc := newMiniredisClient(t)
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
+
+	result, err := reconcileProfile(t, r, "nonexistent")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 0 {
+		t.Errorf("expected no requeue for not-found profile, got %v", result.RequeueAfter)
+	}
+}
+
+func TestReconcile_NoBallastConfig(t *testing.T) {
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(profile) // no BallastConfig
+	_, sc := newMiniredisClient(t)
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue when BallastConfig is absent")
+	}
+}
+
+func TestReconcile_NoMatchingPolicy(t *testing.T) {
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), profile)
+	// No ClusterResourcePolicy that matches
+	_, sc := newMiniredisClient(t)
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue when no policy matches")
+	}
+}
+
+func TestReconcile_KillSwitchActive(t *testing.T) {
+	ctx := context.Background()
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	_, sc := newMiniredisClient(t)
+
+	// Seed the profile status via fake client.
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, activeKS(t), false, p)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue when kill switch active")
+	}
+
+	// No samples should have been written to Redis.
+	tupleHash := store.TupleHash(map[string]string{"app": "web"})
+	key := store.MetricKey(tupleHash, "app", "cpu")
+	count, _ := store.SampleCount(ctx, sc, key)
+	if count != 0 {
+		t.Errorf("expected 0 Redis samples when kill switch active, got %d", count)
+	}
+}
+
+func TestReconcile_DryRun(t *testing.T) {
+	ctx := context.Background()
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), true, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No samples written.
+	tupleHash := store.TupleHash(map[string]string{"app": "web"})
+	key := store.MetricKey(tupleHash, "app", "cpu")
+	count, _ := store.SampleCount(ctx, sc, key)
+	if count != 0 {
+		t.Errorf("expected 0 Redis samples in dry-run, got %d", count)
+	}
+
+	// Status not updated.
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if len(got.Status.Containers) != 0 {
+		t.Errorf("expected no containers in status during dry-run, got %d", len(got.Status.Containers))
+	}
+}
+
+func TestReconcile_MetricsSourceNotFound(t *testing.T) {
+	// Policy references "missing-source" which doesn't exist.
+	policy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-defaults"},
+		Spec: ballastv1.ClusterResourcePolicySpec{
+			Metrics: []ballastv1.MetricConfig{
+				{Resource: "cpu", Field: "request", Source: "missing-source", Aggregation: "p95", Headroom: "1.0"},
+			},
+		},
+	}
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), policy, profile)
+	if err := fc.Status().Update(context.Background(), profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should still requeue.
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue even when source is missing")
+	}
+}
+
+func TestReconcile_CollectAndUpdate(t *testing.T) {
+	ctx := context.Background()
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	p := &mockPlugin{
+		typeName: "kubernetesMetrics",
+		samples: []plugin.ContainerStats{
+			cpuSample("app", 100, now.Add(-2*time.Second)),
+			cpuSample("app", 200, now.Add(-time.Second)),
+			cpuSample("app", 300, now),
+		},
+	}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Samples should be written to Redis.
+	tupleHash := store.TupleHash(tupleLabels)
+	key := store.MetricKey(tupleHash, "app", "cpu")
+	count, err := store.SampleCount(ctx, sc, key)
+	if err != nil {
+		t.Fatalf("SampleCount: %v", err)
+	}
+	if count != 3 {
+		t.Errorf("Redis sample count: got %d, want 3", count)
+	}
+
+	// WorkloadProfile status should be updated.
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if len(got.Status.Containers) == 0 {
+		t.Fatal("expected containers in status after collection")
+	}
+	appContainer := got.Status.Containers[0]
+	if appContainer.Name != "app" {
+		t.Errorf("container name: got %q, want %q", appContainer.Name, "app")
+	}
+	if len(appContainer.UsageStats) == 0 {
+		t.Fatal("expected usage stats for app container")
+	}
+	if appContainer.UsageStats[0].Samples != 3 {
+		t.Errorf("samples: got %d, want 3", appContainer.UsageStats[0].Samples)
+	}
+}
+
+func TestReconcile_ReadinessNotMet(t *testing.T) {
+	ctx := context.Background()
+	// Policy requires 100 data points — we'll only send 1.
+	policy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-defaults"},
+		Spec: ballastv1.ClusterResourcePolicySpec{
+			Metrics: []ballastv1.MetricConfig{
+				{Resource: "cpu", Field: "request", Source: "k8s-metrics", Aggregation: "p95", Headroom: "1.2"},
+			},
+			Readiness: ballastv1.ReadinessConfig{
+				MinDataPoints: 100,
+				MinTimeSpan:   "1ms",
+				MaxCV:         "99.0",
+			},
+		},
+	}
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), policy, defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if got.Status.MeetsThreshold {
+		t.Error("expected meetsThreshold=false when minDataPoints not met")
+	}
+	if len(got.Status.Containers) > 0 && got.Status.Containers[0].Recommendations != nil {
+		t.Error("expected no recommendations when readiness not met")
+	}
+}
+
+func TestReconcile_ReadinessMet_RecommendationsPopulated(t *testing.T) {
+	ctx := context.Background()
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	// Two samples with a tiny time spread — policy requires minDataPoints=2, minTimeSpan=1ms.
+	p := &mockPlugin{
+		typeName: "kubernetesMetrics",
+		samples: []plugin.ContainerStats{
+			cpuSample("app", 200, now.Add(-10*time.Millisecond)),
+			cpuSample("app", 400, now),
+		},
+	}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+
+	if !got.Status.MeetsThreshold {
+		t.Error("expected meetsThreshold=true")
+	}
+	if len(got.Status.Containers) == 0 {
+		t.Fatal("expected containers in status")
+	}
+	cpuRec, ok := got.Status.Containers[0].Recommendations["cpu"]
+	if !ok {
+		t.Fatal("expected cpu recommendation")
+	}
+	if cpuRec.Request == "" {
+		t.Error("expected cpu request recommendation to be populated")
+	}
+	if cpuRec.Limit == "" {
+		t.Error("expected cpu limit recommendation to be populated")
+	}
+}
+
+func TestReconcile_ExistingContainersPreserved(t *testing.T) {
+	// If FetchStats returns no samples, existing container stats from a prior cycle
+	// should still be present in the status (merged from existing profile).
+	ctx := context.Background()
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+
+	// Pre-populate profile with a prior cycle's container stats.
+	profile.Status.Containers = []ballastv1.ContainerProfile{{
+		Name: "app",
+		UsageStats: []ballastv1.ContainerUsageStats{
+			{Resource: "cpu", Source: "k8s-metrics", Samples: 5},
+		},
+	}}
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: nil} // no new samples
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	// The app container should still appear (merged from existing status).
+	found := false
+	for _, cp := range got.Status.Containers {
+		if cp.Name == "app" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'app' container to be preserved from previous cycle")
+	}
+}
+
+// -- envtest integration test --
+
+func TestReconciler_SetupWithManager(t *testing.T) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = testEnv.Stop() })
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 newScheme(),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	mr := miniredis.RunT(t)
+	sc := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	t.Cleanup(func() { _ = sc.Close() })
+
+	ks := killswitch.New(mgr.GetClient(), "default")
+	if err := ks.SetupWithManager(mgr); err != nil {
+		t.Fatalf("ks.SetupWithManager: %v", err)
+	}
+	if err := metricscollector.Setup(mgr, ks, sc, false); err != nil {
+		t.Fatalf("metricscollector.Setup: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	mgrErr := make(chan error, 1)
+	go func() { mgrErr <- mgr.Start(ctx) }()
+
+	if !mgr.GetCache().WaitForCacheSync(ctx) {
+		t.Fatal("cache did not sync")
+	}
+
+	c := mgr.GetClient()
+
+	// Create a WorkloadProfile — the controller should reconcile it without error.
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+	}
+	if err := c.Create(ctx, profile); err != nil {
+		t.Fatalf("create WorkloadProfile: %v", err)
+	}
+
+	// Verify the profile is reachable — the controller reconciles but returns early
+	// (no BallastConfig) without error.
+	waitForProfileExists(t, ctx, c, "app--web")
+}
+
+func waitForProfileExists(t *testing.T, ctx context.Context, c client.Client, name string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		var p ballastv1.WorkloadProfile
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, &p); err == nil {
+			return
+		} else if !apierrors.IsNotFound(err) {
+			time.Sleep(50 * time.Millisecond)
+		}
+	}
+	t.Errorf("timed out waiting for WorkloadProfile %q", name)
+}

--- a/internal/controller/metricscollector/controller_test.go
+++ b/internal/controller/metricscollector/controller_test.go
@@ -2,6 +2,7 @@ package metricscollector_test
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -510,6 +511,242 @@ func TestReconcile_ExistingContainersPreserved(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected 'app' container to be preserved from previous cycle")
+	}
+}
+
+func TestReconcile_PluginNotFound(t *testing.T) {
+	// MetricsSource type has no registered plugin — collectAllSamples skips it.
+	src := &ballastv1.MetricsSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8s-metrics"},
+		Spec: ballastv1.MetricsSourceSpec{
+			Type:   "unknownType",
+			Config: ballastv1.MetricsSourceConfig{PollInterval: "60s"},
+		},
+	}
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), src, profile)
+	if err := fc.Status().Update(context.Background(), profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics"} // type mismatch with source
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue even when plugin not found")
+	}
+}
+
+func TestReconcile_FetchStatsError(t *testing.T) {
+	// Plugin returns an error from FetchStats — collectFromSource logs and continues.
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	if err := fc.Status().Update(context.Background(), profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", err: errors.New("metrics unavailable")}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue even when FetchStats fails")
+	}
+}
+
+func TestReconcile_BadAggregation(t *testing.T) {
+	// Policy uses an unknown aggregation — ComputeRecommendation fails, field left empty.
+	ctx := context.Background()
+	badPolicy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-defaults"},
+		Spec: ballastv1.ClusterResourcePolicySpec{
+			Metrics: []ballastv1.MetricConfig{
+				{Resource: "cpu", Field: "request", Source: "k8s-metrics", Aggregation: "badagg", Headroom: "1.0"},
+			},
+			Readiness: ballastv1.ReadinessConfig{MinDataPoints: 2, MinTimeSpan: "1ms", MaxCV: "99.0"},
+		},
+	}
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), badPolicy, defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, now.Add(-10*time.Millisecond)),
+		cpuSample("app", 300, now),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(got.Status.Containers) > 0 {
+		if recs := got.Status.Containers[0].Recommendations; recs != nil {
+			if cpuRec, ok := recs["cpu"]; ok && cpuRec.Request != "" {
+				t.Error("expected empty recommendation when aggregation is invalid")
+			}
+		}
+	}
+}
+
+func TestReconcile_InvalidRetentionWindow(t *testing.T) {
+	// BallastConfig with an unparseable RetentionWindow falls back to 168h default.
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{RetentionWindow: "not-a-duration"},
+	}
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(cfg, defaultPolicy(), defaultMetricsSource(), profile)
+	if err := fc.Status().Update(context.Background(), profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected requeue with invalid retention window")
+	}
+}
+
+func TestReconcile_ShortPollInterval(t *testing.T) {
+	// MetricsSource PollInterval shorter than defaultPollInterval — minPollInterval returns it.
+	src := &ballastv1.MetricsSource{
+		ObjectMeta: metav1.ObjectMeta{Name: "k8s-metrics"},
+		Spec: ballastv1.MetricsSourceSpec{
+			Type:   "kubernetesMetrics",
+			Config: ballastv1.MetricsSourceConfig{PollInterval: "30s", ReservoirSize: 10000},
+		},
+	}
+	profile := defaultProfile(map[string]string{"app": "web"})
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), src, profile)
+	if err := fc.Status().Update(context.Background(), profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	result, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected 30s requeue interval, got %v", result.RequeueAfter)
+	}
+}
+
+func TestReconcile_MemoryMetric(t *testing.T) {
+	// Non-CPU metric exercises quantityToStoreValue and formatResourceValue memory paths.
+	ctx := context.Background()
+	memPolicy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "platform-defaults"},
+		Spec: ballastv1.ClusterResourcePolicySpec{
+			Metrics: []ballastv1.MetricConfig{
+				{Resource: "memory", Field: "request", Source: "k8s-metrics", Aggregation: "p95", Headroom: "1.1"},
+			},
+			Readiness: ballastv1.ReadinessConfig{MinDataPoints: 2, MinTimeSpan: "1ms", MaxCV: "99.0"},
+		},
+	}
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), memPolicy, defaultMetricsSource(), profile)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	p := &mockPlugin{
+		typeName: "kubernetesMetrics",
+		samples: []plugin.ContainerStats{
+			{ContainerName: "app", Resource: "memory", Value: *resource.NewQuantity(128*1024*1024, resource.BinarySI), Timestamp: now.Add(-10 * time.Millisecond)},
+			{ContainerName: "app", Resource: "memory", Value: *resource.NewQuantity(256*1024*1024, resource.BinarySI), Timestamp: now},
+		},
+	}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !got.Status.MeetsThreshold {
+		t.Error("expected meetsThreshold=true")
+	}
+	if len(got.Status.Containers) == 0 {
+		t.Fatal("expected containers in status")
+	}
+	memRec, ok := got.Status.Containers[0].Recommendations["memory"]
+	if !ok {
+		t.Fatal("expected memory recommendation")
+	}
+	if memRec.Request == "" {
+		t.Error("expected memory request to be populated")
+	}
+}
+
+func TestReconcile_DuplicateContainerMerge(t *testing.T) {
+	// Existing profile has app/cpu AND new FetchStats also returns app/cpu.
+	// mergeContainerSets calls appendUnique twice for the same pair; second call returns early.
+	ctx := context.Background()
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	fc := newFakeClient(defaultBallastConfig(), defaultPolicy(), defaultMetricsSource(), profile)
+	profile.Status.Containers = []ballastv1.ContainerProfile{{
+		Name:       "app",
+		UsageStats: []ballastv1.ContainerUsageStats{{Resource: "cpu", Source: "k8s-metrics", Samples: 5}},
+	}}
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+	_, sc := newMiniredisClient(t)
+	p := &mockPlugin{typeName: "kubernetesMetrics", samples: []plugin.ContainerStats{
+		cpuSample("app", 200, time.Now()),
+	}}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	_, err := reconcileProfile(t, r, "app--web")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	found := false
+	for _, cp := range got.Status.Containers {
+		if cp.Name == "app" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected app container in status after duplicate merge")
 	}
 }
 

--- a/internal/stats/aggregator.go
+++ b/internal/stats/aggregator.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package stats
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/store"
+)
+
+// EvaluateReadiness returns true when all three readiness conditions are satisfied:
+// sampleCount >= minDataPoints, timeSpan >= minTimeSpan, and CV <= maxCV.
+// firstMs and lastMs are Unix timestamps (milliseconds) of the oldest and newest samples.
+func EvaluateReadiness(s store.Stats, firstMs, lastMs int64, cfg ballastv1.ReadinessConfig) bool {
+	if int64(s.Count) < cfg.MinDataPoints {
+		return false
+	}
+
+	minSpan, err := time.ParseDuration(cfg.MinTimeSpan)
+	if err != nil || minSpan <= 0 {
+		minSpan = 24 * time.Hour
+	}
+	if time.Duration(lastMs-firstMs)*time.Millisecond < minSpan {
+		return false
+	}
+
+	maxCV, err := strconv.ParseFloat(strings.TrimSpace(cfg.MaxCV), 64)
+	if err != nil || maxCV < 0 {
+		maxCV = 1.5
+	}
+	return s.CV <= maxCV
+}
+
+// ComputeRecommendation returns the recommended resource.Quantity for metric.
+// Stats values must be in millicores for CPU and bytes for memory/ephemeral-storage.
+func ComputeRecommendation(s store.Stats, metric ballastv1.MetricConfig) (resource.Quantity, error) {
+	var base float64
+	switch metric.Aggregation {
+	case "p50":
+		base = s.P50
+	case "p95":
+		base = s.P95
+	case "p99":
+		base = s.P99
+	case "max":
+		base = s.Max
+	case "avg":
+		base = s.Mean
+	default:
+		return resource.Quantity{}, fmt.Errorf("unknown aggregation %q", metric.Aggregation)
+	}
+
+	headroom := 1.0
+	if h, err := strconv.ParseFloat(strings.TrimSpace(metric.Headroom), 64); err == nil && h > 0 {
+		headroom = h
+	}
+
+	value := int64(base * headroom)
+	if metric.Resource == "cpu" {
+		return *resource.NewMilliQuantity(value, resource.DecimalSI), nil
+	}
+	return *resource.NewQuantity(value, resource.BinarySI), nil
+}

--- a/internal/stats/aggregator_test.go
+++ b/internal/stats/aggregator_test.go
@@ -1,0 +1,186 @@
+package stats_test
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/stats"
+	"github.com/tight-line/ballast/internal/store"
+)
+
+func TestEvaluateReadiness(t *testing.T) {
+	cfg := ballastv1.ReadinessConfig{
+		MinDataPoints: 10,
+		MinTimeSpan:   "1h",
+		MaxCV:         "1.5",
+	}
+
+	// 1h in milliseconds
+	spanMs := int64(60 * 60 * 1000)
+
+	tests := []struct {
+		name    string
+		s       store.Stats
+		firstMs int64
+		lastMs  int64
+		cfg     ballastv1.ReadinessConfig
+		want    bool
+	}{
+		{
+			name:    "all conditions pass",
+			s:       store.Stats{Count: 20, CV: 0.5},
+			firstMs: 0, lastMs: spanMs,
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name:    "too few data points",
+			s:       store.Stats{Count: 5, CV: 0.5},
+			firstMs: 0, lastMs: spanMs,
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name:    "time span too short",
+			s:       store.Stats{Count: 20, CV: 0.5},
+			firstMs: 0, lastMs: spanMs / 2,
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name:    "CV too high",
+			s:       store.Stats{Count: 20, CV: 2.0},
+			firstMs: 0, lastMs: spanMs,
+			cfg:  cfg,
+			want: false,
+		},
+		{
+			name:    "CV exactly at max",
+			s:       store.Stats{Count: 10, CV: 1.5},
+			firstMs: 0, lastMs: spanMs,
+			cfg:  cfg,
+			want: true,
+		},
+		{
+			name:    "invalid minTimeSpan falls back to 24h default",
+			s:       store.Stats{Count: 20, CV: 0.5},
+			firstMs: 0, lastMs: spanMs, // only 1h, less than 24h default
+			cfg: ballastv1.ReadinessConfig{
+				MinDataPoints: 10,
+				MinTimeSpan:   "not-a-duration",
+				MaxCV:         "1.5",
+			},
+			want: false,
+		},
+		{
+			name:    "invalid maxCV falls back to 1.5 default",
+			s:       store.Stats{Count: 20, CV: 1.6},
+			firstMs: 0, lastMs: spanMs,
+			cfg: ballastv1.ReadinessConfig{
+				MinDataPoints: 10,
+				MinTimeSpan:   "1h",
+				MaxCV:         "bad",
+			},
+			want: false,
+		},
+		{
+			name:    "exactly at minDataPoints",
+			s:       store.Stats{Count: 10, CV: 0.5},
+			firstMs: 0, lastMs: spanMs,
+			cfg:  cfg,
+			want: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := stats.EvaluateReadiness(tc.s, tc.firstMs, tc.lastMs, tc.cfg)
+			if got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestComputeRecommendation(t *testing.T) {
+	s := store.Stats{
+		P50:  100,
+		P95:  200,
+		P99:  300,
+		Max:  400,
+		Mean: 150,
+	}
+
+	tests := []struct {
+		name    string
+		metric  ballastv1.MetricConfig
+		want    resource.Quantity
+		wantErr bool
+	}{
+		{
+			name:   "cpu p95 with headroom",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p95", Headroom: "1.2"},
+			want:   resource.MustParse("240m"), // 200 * 1.2 = 240m
+		},
+		{
+			name:   "cpu p99 with headroom",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p99", Headroom: "1.25"},
+			want:   resource.MustParse("375m"), // 300 * 1.25 = 375m
+		},
+		{
+			name:   "memory p99 bytes",
+			metric: ballastv1.MetricConfig{Resource: "memory", Aggregation: "p99", Headroom: "1.1"},
+			want:   *resource.NewQuantity(330, resource.BinarySI), // 300 * 1.1 = 330
+		},
+		{
+			name:   "p50 aggregation",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p50", Headroom: "1.0"},
+			want:   resource.MustParse("100m"),
+		},
+		{
+			name:   "max aggregation",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "max", Headroom: "1.0"},
+			want:   resource.MustParse("400m"),
+		},
+		{
+			name:   "avg aggregation",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "avg", Headroom: "1.0"},
+			want:   resource.MustParse("150m"),
+		},
+		{
+			name:    "unknown aggregation returns error",
+			metric:  ballastv1.MetricConfig{Resource: "cpu", Aggregation: "unknown", Headroom: "1.0"},
+			wantErr: true,
+		},
+		{
+			name:   "invalid headroom falls back to 1.0",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p95", Headroom: "bad"},
+			want:   resource.MustParse("200m"),
+		},
+		{
+			name:   "zero headroom falls back to 1.0",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p95", Headroom: "0"},
+			want:   resource.MustParse("200m"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := stats.ComputeRecommendation(s, tc.metric)
+			if tc.wantErr {
+				if err == nil {
+					t.Error("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got.Cmp(tc.want) != 0 {
+				t.Errorf("got %v, want %v", got.String(), tc.want.String())
+			}
+		})
+	}
+}

--- a/internal/stats/aggregator_test.go
+++ b/internal/stats/aggregator_test.go
@@ -132,7 +132,7 @@ func TestComputeRecommendation(t *testing.T) {
 		{
 			name:   "memory p99 bytes",
 			metric: ballastv1.MetricConfig{Resource: "memory", Aggregation: "p99", Headroom: "1.1"},
-			want:   *resource.NewQuantity(330, resource.BinarySI), // 300 * 1.1 = 330
+			want:   *resource.NewQuantity(330, resource.BinarySI),
 		},
 		{
 			name:   "p50 aggregation",


### PR DESCRIPTION
## Summary

- Adds `internal/controller/metricscollector/controller.go`: reconciles `WorkloadProfile` objects on a `RequeueAfter` timer; fetches container metrics via the plugin interface, writes samples to Redis, computes statistics, evaluates readiness, and updates `WorkloadProfile` status with usage stats and resource recommendations
- Adds `internal/stats/aggregator.go` with pure `EvaluateReadiness` and `ComputeRecommendation` functions
- Wires up a shared `KillSwitch` in `cmd/ballastd/main.go`; both `WorkloadWatcher` and `MetricsCollector` receive the same instance (registered once)
- Adds `--dry-run-measure` flag: skips Redis writes and status updates but logs what would have happened

## Test plan

- [x] `internal/stats/aggregator_test.go`: 9 unit tests covering all aggregation types, readiness boundary conditions, and fallback parsing
- [x] `internal/controller/metricscollector/controller_test.go`: 10 unit tests covering kill switch, dry-run, missing policy, missing metrics source, normal collect-and-update path, readiness met/unmet, and container preservation; 1 envtest integration test for `SetupWithManager`
- [x] `make test-coverage-check` passes in CI (envtest binaries are downloaded by the Makefile `setup-envtest` target)