### PR TITLE
Phase 9: admission webhook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,3 +8,9 @@ Before opening or finalizing a PR, keep these two files consistent with each oth
 - `README.md` — update the Implementation Status table to match
 
 Rule: if all features of a phase are done and a PR is open, mark the phase complete (`[x]` / "Complete"). PRs are only opened once the feature set is finished.
+
+## Coverage gate: required before every commit
+
+A commit is not complete until `make test-coverage-check` passes (which runs `make check` internally).
+
+When a line is uncovered: write a test for it first. Use `// coverage:ignore - <reason>` only when testing is genuinely impossible (e.g. `json.Marshal` on a well-typed struct, transient API errors that require a broken client). Do not use `// coverage:ignore` as a first resort — it defeats the purpose of the coverage gate.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -363,9 +363,9 @@ _Deploy to test cluster. After one `pollInterval`, confirm `WorkloadProfile` sta
 
 ## Phase 9 — Admission Webhook
 
-**Status:** `[ ]`
+**Status:** `[x]`
 **Depends on:** Phases 3, 4, 7, 8
-**PR:** —
+**PR:** https://github.com/Tight-Line/ballast/pull/13
 
 ### What to build
 
@@ -389,11 +389,12 @@ _Deploy to test cluster. After one `pollInterval`, confirm `WorkloadProfile` sta
   - `meetsThreshold: false` → no patch even with `apply` annotation
   - autoresize/automagic: before threshold (measure-only), after threshold (full behavior)
 
-### Key files (fill in after complete)
+### Key files
 
-- `internal/webhook/pod_mutator.go`
-- `internal/webhook/pod_mutator_test.go`
-- `cmd/ballastd/main.go` (webhook registration)
+- `internal/webhook/pod_mutator.go` — `PodMutator` admission handler; `Handle`, `resolveApplyProfile`, `mutate`, `stampPolicyRef`, `lookupProfile`, `applyRecommendations`
+- `internal/webhook/pod_mutator_test.go` — 19 unit tests + envtest `SetupWithManager` test
+- `cmd/ballastd/main.go` — `--dry-run-apply` flag; `NewPodMutator(...).SetupWithManager(mgr)` registration
+- `internal/controller/workloadwatcher/controller.go` — exported `ProfileName` and `ExtractTupleLabels` for webhook use
 
 ### User testing instructions
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -365,7 +365,7 @@ _Deploy to test cluster. After one `pollInterval`, confirm `WorkloadProfile` sta
 
 **Status:** `[x]`
 **Depends on:** Phases 3, 4, 7, 8
-**PR:** https://github.com/Tight-Line/ballast/pull/13
+**PR:** https://github.com/Tight-Line/ballast/pull/12
 
 ### What to build
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Progressive modes (`autoresize`, `automagic`) start in measure-only mode and aut
 | 6 | Plugin interface and `kubernetesMetrics` plugin | Complete |
 | 7 | WorkloadWatcher controller | Complete |
 | 8 | MetricsCollector controller | Complete |
-| 9 | Admission webhook | Not started |
+| 9 | Admission webhook | Complete |
 | 10 | ResourceAdjuster controller | Not started |
 | 11 | Helm chart | Not started |
 | 12 | Polish and release readiness | Not started |

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/tight-line/ballast/internal/killswitch"
 	"github.com/tight-line/ballast/internal/logger"
 	"github.com/tight-line/ballast/internal/store"
+	ballastwebhook "github.com/tight-line/ballast/internal/webhook"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -82,6 +83,10 @@ func main() {
 	var dryRunMeasure bool
 	flag.BoolVar(&dryRunMeasure, "dry-run-measure", false,
 		"If set, metrics are computed but not written to Redis and WorkloadProfile status is not updated.")
+
+	var dryRunApply bool
+	flag.BoolVar(&dryRunApply, "dry-run-apply", false,
+		"If set, resource recommendations are computed at admission time but the pod spec is not patched.")
 
 	var logLevel, logLevelWebhook, logLevelWatcher, logLevelCollector, logLevelAdjuster, logFormat string
 	flag.StringVar(&logLevel, "log-level", "info", "Global log level (debug|info|warn|error).")
@@ -183,6 +188,8 @@ func main() {
 		setupLog.Error(err, "Failed to set up metricscollector controller")
 		os.Exit(1)
 	}
+
+	ballastwebhook.NewPodMutator(mgr.GetClient(), ks, dryRunApply).SetupWithManager(mgr)
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "Failed to set up health check")

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -135,14 +135,14 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		return ctrl.Result{}, err // coverage:ignore - transient API error
 	}
 
-	tupleLabels, err := extractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
+	tupleLabels, err := ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
 	if err != nil {
 		log.Info("pod missing required identity labels, skipping",
 			"pod", pod.Name, "namespace", pod.Namespace, "error", err.Error())
 		return ctrl.Result{}, nil
 	}
 
-	profName := profileName(tupleLabels)
+	profName := ProfileName(tupleLabels)
 
 	if err := r.ensureProfile(ctx, profName, tupleLabels); err != nil { // coverage:ignore - transient API error
 		return ctrl.Result{}, err
@@ -333,9 +333,9 @@ func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// extractTupleLabels returns a map of identityLabel key -> pod label value.
+// ExtractTupleLabels returns a map of identityLabel key -> pod label value.
 // Returns an error listing any keys absent from podLabels.
-func extractTupleLabels(podLabels map[string]string, identityLabels []string) (map[string]string, error) {
+func ExtractTupleLabels(podLabels map[string]string, identityLabels []string) (map[string]string, error) {
 	out := make(map[string]string, len(identityLabels))
 	var missing []string
 	for _, k := range identityLabels {
@@ -352,10 +352,10 @@ func extractTupleLabels(podLabels map[string]string, identityLabels []string) (m
 	return out, nil
 }
 
-// profileName derives a deterministic Kubernetes-safe name from a label tuple.
+// ProfileName derives a deterministic Kubernetes-safe name from a label tuple.
 // Keys are sorted alphabetically and joined with values as "key--value" pairs
 // separated by "--". Each segment is sanitized to lowercase alphanumeric-and-dash.
-func profileName(tupleLabels map[string]string) string {
+func ProfileName(tupleLabels map[string]string) string {
 	keys := make([]string, 0, len(tupleLabels))
 	for k := range tupleLabels {
 		keys = append(keys, k)

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/controller/workloadwatcher"
+	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/policy"
+	"github.com/tight-line/ballast/internal/validation"
+)
+
+// PodMutator implements admission.Handler for pod CREATE requests.
+// It validates Ballast annotations, resolves the active WorkloadProfile,
+// and patches container resource requests/limits when the profile is ready.
+type PodMutator struct {
+	client      client.Client
+	ks          *killswitch.KillSwitch
+	resolver    *policy.Resolver
+	dryRunApply bool
+}
+
+// NewPodMutator creates a PodMutator backed by the given client and kill switch.
+func NewPodMutator(c client.Client, ks *killswitch.KillSwitch, dryRunApply bool) *PodMutator {
+	log := ctrl.Log.WithName("webhook")
+	return &PodMutator{
+		client:      c,
+		ks:          ks,
+		resolver:    policy.NewResolver(c, log),
+		dryRunApply: dryRunApply,
+	}
+}
+
+// SetupWithManager registers the PodMutator handler with the manager's webhook server.
+func (m *PodMutator) SetupWithManager(mgr ctrl.Manager) {
+	mgr.GetWebhookServer().Register("/mutate-v1-pod", &admission.Webhook{Handler: m})
+}
+
+// Handle processes a pod admission request.
+func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admission.Response {
+	log := ctrl.Log.WithName("webhook").WithValues("pod", req.Name, "namespace", req.Namespace)
+
+	if m.ks.IsActive() {
+		log.Info("kill switch active, skipping mutation", "reason", m.ks.Reason())
+		return admission.Allowed("kill switch active")
+	}
+
+	var pod corev1.Pod
+	if err := json.Unmarshal(req.Object.Raw, &pod); err != nil {
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("decoding pod: %w", err))
+	}
+
+	if err := validation.ValidateAnnotations(pod.Annotations); err != nil {
+		return admission.Denied(err.Error())
+	}
+
+	profile, ok, err := m.resolveApplyProfile(ctx, &pod)
+	if err != nil {
+		log.V(1).Info("profile resolution error, allowing without mutation", "err", err)
+		return admission.Allowed("profile not available")
+	}
+	if !ok {
+		return admission.Allowed("apply not active or profile not ready")
+	}
+
+	return m.mutate(ctx, &pod, profile)
+}
+
+// resolveApplyProfile returns the WorkloadProfile to use for patching, and true if apply
+// should proceed. Returns (nil, false, nil) when apply is not requested or the profile is
+// not ready — both are normal non-error states.
+func (m *PodMutator) resolveApplyProfile(ctx context.Context, pod *corev1.Pod) (*ballastv1.WorkloadProfile, bool, error) {
+	if !wantsApply(pod.Annotations) {
+		return nil, false, nil
+	}
+	p, err := m.lookupProfile(ctx, pod)
+	if err != nil {
+		return nil, false, err
+	}
+	if p == nil || !p.Status.MeetsThreshold {
+		return nil, false, nil
+	}
+	return p, true, nil
+}
+
+// wantsApply reports whether the pod carries any annotation that requests resource application.
+func wantsApply(ann map[string]string) bool {
+	for _, key := range []string{
+		validation.AnnotationApply,
+		validation.AnnotationAutoresize,
+		validation.AnnotationAutomagic,
+	} {
+		if v, ok := ann[key]; ok && strings.EqualFold(v, "true") {
+			return true
+		}
+	}
+	return false
+}
+
+// mutate builds the patched pod and returns a JSON-patch admission response.
+func (m *PodMutator) mutate(ctx context.Context, pod *corev1.Pod, profile *ballastv1.WorkloadProfile) admission.Response {
+	log := ctrl.Log.WithName("webhook")
+
+	modifiedPod := pod.DeepCopy()
+	m.stampPolicyRef(ctx, pod, modifiedPod)
+
+	applied := applyRecommendations(modifiedPod, profile)
+	log.Info("applying resource recommendations", "dry_run", m.dryRunApply, "containers", applied)
+
+	if m.dryRunApply {
+		return admission.Allowed("dry-run: apply suppressed")
+	}
+
+	return patchResponse(pod, modifiedPod)
+}
+
+// stampPolicyRef resolves the active policy and stamps its name onto modifiedPod.
+// Policy resolution failures are non-fatal — the admission proceeds without a policy-ref.
+func (m *PodMutator) stampPolicyRef(ctx context.Context, pod, modifiedPod *corev1.Pod) {
+	resolved, err := m.resolver.Resolve(ctx, policy.Input{
+		Namespace:   pod.Namespace,
+		OwnerKind:   directOwnerKind(pod),
+		Labels:      pod.Labels,
+		Annotations: pod.Annotations,
+	})
+	if err != nil { // coverage:ignore - transient API error listing policy objects
+		ctrl.Log.WithName("webhook").V(1).Info("policy resolution error, skipping policy-ref", "err", err)
+		return
+	}
+	if resolved != nil {
+		modifiedPod.Annotations[validation.AnnotationPolicyRef] = resolved.Name
+	}
+}
+
+// lookupProfile resolves the WorkloadProfile for the given pod.
+// Returns (nil, nil) when no profile exists yet — normal for new workloads.
+func (m *PodMutator) lookupProfile(ctx context.Context, pod *corev1.Pod) (*ballastv1.WorkloadProfile, error) {
+	var cfg ballastv1.BallastConfig
+	if err := m.client.Get(ctx, types.NamespacedName{Name: killswitch.BallastConfigName}, &cfg); err != nil {
+		return nil, fmt.Errorf("getting BallastConfig: %w", err)
+	}
+
+	tupleLabels, err := workloadwatcher.ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
+	if err != nil {
+		return nil, fmt.Errorf("extracting tuple labels: %w", err)
+	}
+
+	var wp ballastv1.WorkloadProfile
+	if err := m.client.Get(ctx, types.NamespacedName{Name: workloadwatcher.ProfileName(tupleLabels)}, &wp); err != nil {
+		return nil, nil //nolint:nilerr // not-found is expected for new workloads
+	}
+
+	return &wp, nil
+}
+
+// applyRecommendations patches container resources and records applied-* annotations.
+// Returns the names of containers that received patches.
+func applyRecommendations(pod *corev1.Pod, profile *ballastv1.WorkloadProfile) []string {
+	byName := containerProfilesByName(profile)
+	var applied []string
+	for i := range pod.Spec.Containers {
+		if patchContainerResources(&pod.Spec.Containers[i], byName, pod.Annotations) {
+			applied = append(applied, pod.Spec.Containers[i].Name)
+		}
+	}
+	return applied
+}
+
+func containerProfilesByName(profile *ballastv1.WorkloadProfile) map[string]ballastv1.ContainerProfile {
+	m := make(map[string]ballastv1.ContainerProfile, len(profile.Status.Containers))
+	for _, cp := range profile.Status.Containers {
+		m[cp.Name] = cp
+	}
+	return m
+}
+
+func patchContainerResources(c *corev1.Container, byName map[string]ballastv1.ContainerProfile, ann map[string]string) bool {
+	cp, ok := byName[c.Name]
+	if !ok || len(cp.Recommendations) == 0 {
+		return false
+	}
+	if c.Resources.Requests == nil {
+		c.Resources.Requests = make(corev1.ResourceList)
+	}
+	if c.Resources.Limits == nil {
+		c.Resources.Limits = make(corev1.ResourceList)
+	}
+	for res, rec := range cp.Recommendations {
+		applyResourceField(c.Resources.Requests, ann, res, "request", rec.Request)
+		applyResourceField(c.Resources.Limits, ann, res, "limit", rec.Limit)
+	}
+	return true
+}
+
+func applyResourceField(list corev1.ResourceList, ann map[string]string, res, field, val string) {
+	if val == "" {
+		return
+	}
+	qty, err := resource.ParseQuantity(val)
+	if err != nil {
+		return
+	}
+	list[corev1.ResourceName(res)] = qty
+	ann["ballast.tightlinesoftware.com/applied-"+res+"-"+field] = val
+}
+
+// patchResponse computes a JSON-patch response from original → modified pod.
+func patchResponse(original, modified *corev1.Pod) admission.Response {
+	originalJSON, err := json.Marshal(original)
+	if err != nil { // coverage:ignore - json.Marshal of corev1.Pod cannot fail
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling original pod: %w", err))
+	}
+	modifiedJSON, err := json.Marshal(modified)
+	if err != nil { // coverage:ignore - json.Marshal of corev1.Pod cannot fail
+		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("marshaling modified pod: %w", err))
+	}
+	return admission.PatchResponseFromRaw(originalJSON, modifiedJSON)
+}
+
+// directOwnerKind returns the Kind of the first controller ownerReference on the pod,
+// or empty string if none is set.
+func directOwnerKind(pod *corev1.Pod) string {
+	for _, ref := range pod.OwnerReferences {
+		if ref.Controller != nil && *ref.Controller {
+			return ref.Kind
+		}
+	}
+	return ""
+}

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -1,0 +1,556 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package webhook_test
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/validation"
+	"github.com/tight-line/ballast/internal/webhook"
+)
+
+// -- scheme & client helpers --
+
+func newScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = ballastv1.AddToScheme(s)
+	return s
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithObjects(objs...).
+		Build()
+}
+
+func inactiveKS(t *testing.T) *killswitch.KillSwitch {
+	t.Helper()
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).Build()
+	ks := killswitch.New(fc, "ballast-system")
+	if _, err := ks.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatalf("ks.Reconcile: %v", err)
+	}
+	return ks
+}
+
+func activeKS(t *testing.T) *killswitch.KillSwitch {
+	t.Helper()
+	cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+		Name: killswitch.ConfigMapName, Namespace: "ballast-system",
+	}}
+	fc := fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(cm).Build()
+	ks := killswitch.New(fc, "ballast-system")
+	if _, err := ks.Reconcile(context.Background(), reconcile.Request{}); err != nil {
+		t.Fatalf("ks.Reconcile: %v", err)
+	}
+	return ks
+}
+
+func defaultBallastConfig() *ballastv1.BallastConfig {
+	return &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app"}},
+	}
+}
+
+// readyProfile returns a WorkloadProfile named "app--web" (matching pod label app=web)
+// with cpu+memory recommendations and meetsThreshold=true.
+func readyProfile() *ballastv1.WorkloadProfile {
+	return &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		Status: ballastv1.WorkloadProfileStatus{
+			MeetsThreshold: true,
+			Containers: []ballastv1.ContainerProfile{
+				{
+					Name: "app",
+					Recommendations: map[string]ballastv1.ResourceRecommendation{
+						"cpu":    {Request: "200m", Limit: "400m"},
+						"memory": {Request: "128Mi", Limit: "256Mi"},
+					},
+				},
+			},
+		},
+	}
+}
+
+func notReadyProfile() *ballastv1.WorkloadProfile {
+	return &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		Status:     ballastv1.WorkloadProfileStatus{MeetsThreshold: false},
+	}
+}
+
+// makeRequest builds a synthetic pod CREATE admission request.
+func makeRequest(pod *corev1.Pod) admission.Request {
+	raw, _ := json.Marshal(pod)
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+			Name:      pod.Name,
+			Namespace: pod.Namespace,
+		},
+	}
+}
+
+// testPod returns a minimal pod with the given annotations and label app=web.
+func testPod(name string, anns map[string]string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Annotations: anns,
+			Labels:      map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+			},
+		},
+	}
+}
+
+func hasResourcePatch(resp admission.Response) bool {
+	for _, p := range resp.Patches {
+		if strings.Contains(p.Path, "resources") || strings.Contains(p.Path, "annotations") {
+			return true
+		}
+	}
+	return false
+}
+
+// -- unit tests (fake client) --
+
+func TestPodMutator_KillSwitch(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, activeKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got denied: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches when kill switch active, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_InvalidAnnotations(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationApply: "true", // missing measure
+	})))
+
+	if resp.Allowed {
+		t.Error("expected Denied for invalid annotations, got Allowed")
+	}
+}
+
+func TestPodMutator_NoApplyAnnotation(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed for measure-only pod, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_DryRunApply(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), true /* dryRunApply */)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed in dry-run, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches in dry-run mode, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_SuccessfulPatch(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected resource or annotation patches, got: %v", resp.Patches)
+	}
+}
+
+func TestPodMutator_ProfileNotReady(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), notReadyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed when profile not ready, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches when profile not ready, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_ProfileNotFound(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig()) // no profile object
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed when profile not found, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches when profile not found, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_Autoresize_BelowThreshold(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), notReadyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationAutoresize: "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed (measure-only) for autoresize below threshold, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches below threshold, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_Autoresize_AboveThreshold(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationAutoresize: "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed with patch for autoresize above threshold, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected patches for autoresize above threshold, got: %v", resp.Patches)
+	}
+}
+
+func TestPodMutator_Automagic_BelowThreshold(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), notReadyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationAutomagic: "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed (measure-only) for automagic below threshold, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches below threshold, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_Automagic_AboveThreshold(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationAutomagic: "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed with patch for automagic above threshold, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected patches for automagic above threshold, got: %v", resp.Patches)
+	}
+}
+
+func TestPodMutator_MalformedRequest(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	req := admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: []byte("not-valid-json")},
+		},
+	}
+	resp := m.Handle(context.Background(), req)
+
+	if resp.Allowed {
+		t.Error("expected error response for malformed JSON, got Allowed")
+	}
+}
+
+func TestPodMutator_BallastConfigMissing(t *testing.T) {
+	fc := newFakeClient() // no BallastConfig
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed when BallastConfig missing, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_MissingIdentityLabel(t *testing.T) {
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app", "env"}},
+	}
+	fc := newFakeClient(cfg)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	// pod only has "app", missing "env"
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed when identity label missing, got: %s", resp.Result.Message)
+	}
+	if len(resp.Patches) != 0 {
+		t.Errorf("expected no patches, got %d", len(resp.Patches))
+	}
+}
+
+func TestPodMutator_PolicyRefStamped(t *testing.T) {
+	policy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-policy"},
+		Spec:       ballastv1.ClusterResourcePolicySpec{},
+	}
+	fc := newFakeClient(defaultBallastConfig(), readyProfile(), policy)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+	found := false
+	for _, p := range resp.Patches {
+		if strings.Contains(p.Path, "policy-ref") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected policy-ref annotation patch, patches were: %v", resp.Patches)
+	}
+}
+
+func TestPodMutator_UnmatchedContainer(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	// pod has an extra "sidecar" container not in the profile
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "p",
+			Namespace:   "default",
+			Annotations: map[string]string{validation.AnnotationMeasure: "true", validation.AnnotationApply: "true"},
+			Labels:      map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{
+				{Name: "app", Image: "nginx"},
+				{Name: "sidecar", Image: "envoy"},
+			},
+		},
+	}
+	resp := m.Handle(context.Background(), makeRequest(pod))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected patches for matched container, got none")
+	}
+}
+
+func TestPodMutator_EmptyRecommendationField(t *testing.T) {
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		Status: ballastv1.WorkloadProfileStatus{
+			MeetsThreshold: true,
+			Containers: []ballastv1.ContainerProfile{
+				{
+					Name: "app",
+					Recommendations: map[string]ballastv1.ResourceRecommendation{
+						"cpu": {Request: "200m", Limit: ""}, // empty Limit
+					},
+				},
+			},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected patch for non-empty Request field, got none")
+	}
+}
+
+func TestPodMutator_InvalidQuantity(t *testing.T) {
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		Status: ballastv1.WorkloadProfileStatus{
+			MeetsThreshold: true,
+			Containers: []ballastv1.ContainerProfile{
+				{
+					Name: "app",
+					Recommendations: map[string]ballastv1.ResourceRecommendation{
+						"cpu": {Request: "not-a-quantity", Limit: "not-a-quantity"},
+					},
+				},
+			},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+
+	// webhook allows the pod even when recommendations can't be parsed
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed even with invalid quantity, got: %s", resp.Result.Message)
+	}
+}
+
+func TestPodMutator_OwnerReference(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false)
+
+	isController := true
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "p",
+			Namespace: "default",
+			Annotations: map[string]string{
+				validation.AnnotationMeasure: "true",
+				validation.AnnotationApply:   "true",
+			},
+			Labels: map[string]string{"app": "web"},
+			OwnerReferences: []metav1.OwnerReference{
+				{Kind: "ReplicaSet", Name: "web-rs", Controller: &isController},
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app", Image: "nginx"}},
+		},
+	}
+	resp := m.Handle(context.Background(), makeRequest(pod))
+
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+	if !hasResourcePatch(resp) {
+		t.Errorf("expected patches for pod with owner reference, got none")
+	}
+}
+
+// -- envtest integration test --
+
+func TestPodMutator_SetupWithManager(t *testing.T) {
+	testEnv := &envtest.Environment{
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+	}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = testEnv.Stop() })
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:                 newScheme(),
+		Metrics:                metricsserver.Options{BindAddress: "0"},
+		HealthProbeBindAddress: "0",
+	})
+	if err != nil {
+		t.Fatalf("new manager: %v", err)
+	}
+
+	ks := killswitch.New(mgr.GetClient(), "ballast-system")
+	webhook.NewPodMutator(mgr.GetClient(), ks, false).SetupWithManager(mgr)
+}


### PR DESCRIPTION
## Summary

- Adds `internal/webhook/pod_mutator.go`: a `PodMutator` that implements `admission.Handler` for pod CREATE requests
- Kill switch check, annotation validation, progressive mode resolution (autoresize/automagic gate on `WorkloadProfile.meetsThreshold`), per-container resource patching from profile recommendations, policy-ref stamping
- `--dry-run-apply` flag: computes patch but passes pod through unmodified
- Exports `ProfileName` and `ExtractTupleLabels` from `workloadwatcher` so the webhook can compute profile names independently at admission time
- Registers the handler in `cmd/ballastd/main.go` via `NewPodMutator(...).SetupWithManager(mgr)`
- 19 unit tests + envtest `SetupWithManager` test; webhook package at 95.7% coverage
- `make test-coverage-check` passes (overall filtered coverage 63.2%)

## Test plan

- [x] CI passes (`make check`)

Full cluster testing (cert-manager, live webhook, pod admission) is deferred to Phase 11 (Helm chart), which is when cluster deployment becomes possible.