### PR TITLE
Phase 12: polish and release readiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  release-image:
+    name: Build and push container image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract version from tag
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          TAG=${GITHUB_REF#refs/tags/}
+          echo "VERSION=${VERSION}" >> $GITHUB_OUTPUT
+          echo "TAG=${TAG}" >> $GITHUB_OUTPUT
+          echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
+
+      - name: Build and push (multi-arch)
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.VERSION }}
+          tags: |
+            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:${{ steps.meta.outputs.TAG }}
+            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:latest
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  release-chart:
+    name: Package and publish Helm chart
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Update Helm dependencies
+        run: helm dependency update charts/ballast
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.6.0
+        with:
+          skip_existing: true
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,15 @@
 
 ## Project Overview
 
+Ballast is a Kubernetes operator that automatically right-sizes workload resource requests and limits based on real operational history. Workloads opt in via pod template annotations; Ballast never touches a workload without explicit `ballast.tightlinesoftware.com/measure: "true"`.
+
+The operator has three main behaviors:
+1. **Measure** — collect per-container CPU/memory usage samples into Redis time-series keys
+2. **Apply** — patch resource requests/limits at admission time when a pod is admitted
+3. **Resize** — adjust resources on running pods via the Kubernetes in-place resize API (1.35+)
+
+Nothing is applied or resized until the matching `WorkloadProfile` has accumulated enough history and its `meetsThreshold` field is true. `autoresize` is simply shorthand for `measure + apply + resize` as a single annotation.
+
 ## Quick Start
 
 ```bash
@@ -20,23 +29,247 @@ make generate     # Regenerate DeepCopy methods
 
 ## Key Files
 
+| File | Purpose |
+|---|---|
+| `cmd/ballastd/main.go` | Entry point; all CLI flags; creates kubebuilder manager; registers kill switch, all controllers, and webhook |
+| `api/v1/ballastconfig_types.go` | `BallastConfig` CRD — cluster-scoped singleton; `identityLabels`, `orphanTTL`, `retentionWindow`, `suspended` |
+| `api/v1/metricssource_types.go` | `MetricsSource` CRD — names a plugin type (`spec.type`) and its poll config |
+| `api/v1/clusterresourcepolicy_types.go` | `ClusterResourcePolicy` CRD — selector, metrics slice, readiness config, behaviors |
+| `api/v1/resourcepolicy_types.go` | `ResourcePolicy` CRD — same spec as `ClusterResourcePolicy`; namespace-scoped; always beats `ClusterResourcePolicy` |
+| `api/v1/workloadprofile_types.go` | `WorkloadProfile` CRD — status-only; `tupleLabels`, `containers` (usageStats + recommendations), `meetsThreshold`, `activeWorkloads`, conditions |
+| `internal/killswitch/killswitch.go` | `KillSwitch` reconciler; `IsActive()`/`Reason()` hot path; watches ConfigMap `ballast-kill-switch` and `BallastConfig.spec.suspended` |
+| `internal/logger/logger.go` | `New(component, level, format) logr.Logger` backed by zap; `newWithWriter` is the testable variant |
+| `internal/policy/resolver.go` | `Resolver`; `Resolve(ctx, Input) (*ResolvedPolicy, error)` — evaluates namespace/annotation/label selectors; `ResourcePolicy` beats `ClusterResourcePolicy` regardless of priority |
+| `internal/store/client.go` | `Client` interface (go-redis subset); `NewClient(redisURL)` |
+| `internal/store/keys.go` | `TupleHash(labels)`, `MetricKey(hash, container, resource)`, `AllKeysForHash(ctx, client, hash)` |
+| `internal/store/metrics.go` | `AddSample`, `QueryWindow`, `ExpireOlderThan`, `SampleCount`, `TimeRange`, `DeleteKey`, `EnforceReservoirCap` |
+| `internal/store/percentiles.go` | `ComputeStats([]int64) Stats` — p50/p95/p99/max/mean/stddev/CV |
+| `internal/plugin/plugin.go` | `MetricsPlugin` interface; `WorkloadIdentity`, `TimeWindow`, `ContainerStats` types |
+| `internal/plugin/registry.go` | `Register(p)`, `Get(typeName)` — global plugin registry; plugins self-register via `init()` |
+| `internal/plugin/kubernetes/plugin.go` | `kubernetesMetrics` plugin — calls in-cluster metrics API; token-bucket rate limiting; exponential backoff on errors |
+| `internal/stats/aggregator.go` | `EvaluateReadiness(Stats, firstMs, lastMs, ReadinessConfig) bool`; `ComputeRecommendation(Stats, MetricConfig) (resource.Quantity, error)` |
+| `internal/validation/annotations.go` | `ValidateAnnotations(map[string]string) error` — enforces annotation combination rules |
+| `internal/controller/workloadwatcher/controller.go` | Watches pods; creates/updates `WorkloadProfile`; `ProfileName(tupleLabels)` and `ExtractTupleLabels(podLabels, identityLabels)` exported for webhook use |
+| `internal/controller/metricscollector/controller.go` | Reconciles `WorkloadProfile` on timer; polls plugins; writes to Redis; updates status with stats and recommendations |
+| `internal/controller/resourceadjuster/controller.go` | Watches `WorkloadProfile` status changes; detects drift; issues in-place pod resize patches; exports `ExceedsDrift`, `CapChange`, `ResolveFieldThreshold`, `ParseResizeInterval` |
+| `internal/webhook/pod_mutator.go` | `PodMutator` admission handler; `Handle`, `resolveApplyProfile`, `mutate`, `applyRecommendations`; registered at `/mutate-v1-pod` |
+| `charts/ballast/values.yaml` | All Helm configurable settings with defaults |
+| `charts/ballast/templates/deployment.yaml` | Operator deployment; mounts cert Secret; passes all CLI flags from values |
+| `charts/ballast/templates/mutatingwebhookconfiguration.yaml` | Webhook registration; `failurePolicy: Fail`; cert-manager `caBundle` injection annotation |
+| `charts/ballast/templates/ballastconfig.yaml` | Creates the `BallastConfig` singleton from Helm values |
+
 ## Architecture
+
+```
+Pod CREATE ──► PodMutator (admission webhook)
+                  │  validates annotations
+                  │  applies recommendations if profile ready (meetsThreshold)
+                  │
+                  ▼
+           WorkloadWatcher (controller, pod events)
+                  │  creates WorkloadProfile on first pod seen
+                  │  stamps ballast.tightlinesoftware.com/profile-ref on pod
+                  │  increments/decrements activeWorkloads
+                  │  triggers orphan TTL cleanup
+                  │
+                  ▼
+           MetricsCollector (controller, timer)
+                  │  polls kubernetesMetrics plugin
+                  │  writes samples to Redis sorted sets
+                  │  enforces retention window + reservoir cap
+                  │  computes p50/p95/p99/CV; evaluates readiness
+                  │  updates WorkloadProfile status with recommendations
+                  │
+                  ▼
+           ResourceAdjuster (controller, WorkloadProfile events)
+                  │  detects drift between current and recommended values
+                  │  caps adjustment per cycle (maxChangePerCycle)
+                  └──► in-place pod resize (Kubernetes 1.35+)
+```
+
+KillSwitch is a side controller that caches whether the emergency ConfigMap exists or `BallastConfig.spec.suspended` is true. All controllers call `ks.IsActive()` before taking any external action and log at `warn` with `kill_switch: true` when suppressed.
 
 ## CRD Types
 
+All types are in `api/v1/`. Auto-generated files (`zz_generated.*.go`) must never be edited directly — regenerate with `make generate` (deepcopy) or `make manifests` (CRDs, RBAC).
+
+| Kind | Scope | Purpose |
+|---|---|---|
+| `BallastConfig` | Cluster | Singleton config: `identityLabels`, `orphanTTL`, `retentionWindow`, `suspended` |
+| `MetricsSource` | Cluster | Links a plugin type name (`spec.type`) to poll config (`pollInterval`, `reservoirSize`) |
+| `ClusterResourcePolicy` | Cluster | Selector (kinds, namespaces, annotations, labelSelector) + metrics slice + readiness + behaviors |
+| `ResourcePolicy` | Namespace | Same spec as `ClusterResourcePolicy`; namespace-scoped; overrides any `ClusterResourcePolicy` |
+| `WorkloadProfile` | Cluster | Status-only; holds usage stats, recommendations, `meetsThreshold`, `activeWorkloads`, and conditions |
+
+`WorkloadProfile` names are derived by sorting identity label values and joining them with `--`, e.g., labels `{app: billing, component: api}` → `billing--api`. The `ProfileName(tupleLabels)` function in `internal/controller/workloadwatcher/controller.go` is authoritative.
+
 ## Controllers
+
+### KillSwitch (`internal/killswitch/`)
+
+Not a workload reconciler — it watches the `ballast-kill-switch` ConfigMap (in the operator namespace) and the `BallastConfig` singleton, then caches the result in an in-memory `sync.RWMutex`. `IsActive()` and `Reason()` acquire only a read lock. Registered via `ks.SetupWithManager(mgr)`.
+
+### WorkloadWatcher (`internal/controller/workloadwatcher/`)
+
+Two reconcilers share the package:
+
+- `PodReconciler` — watches pods carrying any Ballast behavior annotation. On CREATE: reads `BallastConfig.identityLabels`, extracts the identity tuple, creates `WorkloadProfile` if absent, increments `activeWorkloads`, stamps `profile-ref` annotation on the pod. On DELETE: decrements `activeWorkloads`; sets `Orphaned` condition when it reaches zero. Kill switch suppresses CREATE path only; DELETE path always runs so accounting stays correct.
+- `ProfileReconciler` — watches `WorkloadProfile` objects. Checks orphan TTL; if exceeded, purges Redis keys via `AllKeysForHash`/`DeleteKey` and deletes the profile.
+
+Exported helpers used by the webhook: `ExtractTupleLabels(podLabels, identityLabels)` and `ProfileName(tupleLabels)`.
+
+### MetricsCollector (`internal/controller/metricscollector/`)
+
+Reconciles `WorkloadProfile` objects. On each cycle:
+1. Resolves matched policy via `policy.Resolver`; loads `MetricsSource` from policy
+2. Looks up plugin from the global registry by source type
+3. Calls `plugin.FetchStats(ctx, identity, window)`
+4. Writes samples to Redis; enforces retention window and reservoir cap
+5. Queries Redis for the full retention window; computes stats via `store.ComputeStats`
+6. Evaluates readiness via `stats.EvaluateReadiness`
+7. If ready, computes recommendations via `stats.ComputeRecommendation`
+8. Updates `WorkloadProfile` status
+
+Dry-run (`--dry-run-measure`) skips steps 4 and 8. Kill switch skips both.
+
+### ResourceAdjuster (`internal/controller/resourceadjuster/`)
+
+Triggered by `WorkloadProfile` status changes and a periodic requeue timer (`behaviors.resize.interval`, default 15 minutes). For each pod with `resize` (or `autoresize`) annotation and a ready profile:
+1. Calls `ExceedsDrift(current, recommended, thresholdPct)` per container/resource/field
+2. If drift exceeded, calls `CapChange(current, recommended, maxChangePct)` to bound the adjustment
+3. Issues the resize patch via the pod resize subresource
+4. On failure (node pressure, infeasible): emits a Kubernetes Event and stamps `resize-blocked` annotation; retries on next cycle
+
+Threshold lookup follows a coalesce chain: per-resource field override → resize default → global default (20%). Dry-run (`--dry-run-resize`) logs the resize without patching. Kill switch suppresses all action.
 
 ## Admission Webhook
 
+`internal/webhook/pod_mutator.go` — registered at `/mutate-v1-pod` for pod CREATE.
+
+Flow:
+1. Kill switch active → allow without mutation; log `warn`
+2. `ValidateAnnotations` fails → deny with descriptive message
+3. Profile not ready (`meetsThreshold` false) → allow without mutation
+4. `apply` or `autoresize` annotation present + profile ready → patch container `resources.requests` and `resources.limits` per profile recommendations; stamp `policy-ref` annotation
+5. Dry-run (`--dry-run-apply`) → log the patch, admit without mutation
+
+TLS: the Helm chart creates a cert-manager `Issuer` + `Certificate` (self-signed). cert-manager injects the `caBundle` into `MutatingWebhookConfiguration` automatically.
+
 ## Plugin Interface
+
+`internal/plugin/plugin.go` defines the interface all metrics plugins must implement:
+
+```go
+type MetricsPlugin interface {
+    Type() string
+    FetchStats(ctx context.Context, id WorkloadIdentity, window TimeWindow) ([]ContainerStats, error)
+}
+```
+
+The global registry in `internal/plugin/registry.go` maps type names to plugin instances. Plugins self-register from `init()`.
+
+### Adding a new plugin
+
+1. Create `internal/plugin/<name>/plugin.go` implementing `MetricsPlugin`.
+2. Call `plugin.Register(&MyPlugin{})` in the package `init()` function.
+3. Add a blank import of your plugin package in `cmd/ballastd/main.go`.
+4. Create a `MetricsSource` object in the cluster with `spec.type` matching your `Type()` return value.
+
+The built-in `kubernetesMetrics` plugin calls the in-cluster metrics API. It ignores the `TimeWindow` parameter and returns current point-in-time measurements. External plugins (e.g., Prometheus) should use the window for historical range queries.
+
+The `kubernetesMetrics` plugin uses a token-bucket rate limiter (configurable RPS) and exponential backoff (base 1s, configurable max, default ceiling 5 minutes) on API errors. New plugins should implement similar defensive patterns.
 
 ## Redis Data Model
 
+Keys follow the pattern `ballast:metrics:{tupleHash}:{container}:{resource}`.
+
+- `tupleHash` — 16-character lowercase hex prefix of SHA-256 of sorted `key=value\n` pairs from the identity tuple (see `store.TupleHash`)
+- `container` — container name as it appears in the pod spec
+- `resource` — `cpu`, `memory`, or `ephemeral-storage`
+
+Each key is a Redis sorted set. Score = Unix timestamp in milliseconds. Member = string-encoded value (millicores for CPU, bytes for memory/ephemeral-storage).
+
+Key helpers in `internal/store/`:
+- `TupleHash(labels map[string]string) string` — deterministic hash
+- `MetricKey(tupleHash, container, resource string) string` — full key
+- `AllKeysForHash(ctx, client, tupleHash) ([]string, error)` — scans with `SCAN` + prefix match for orphan cleanup
+
 ## Testing Strategy
+
+- **Controller tests** — use `sigs.k8s.io/controller-runtime/pkg/envtest` (embedded etcd + API server). Tests live alongside their controller as `*_test.go`.
+- **Redis store tests** — use `github.com/alicebob/miniredis/v2` as a drop-in `Client`. No real Redis required.
+- **Policy and validation tests** — pure unit tests using a fake controller-runtime client.
+- **Webhook tests** — envtest with a self-signed cert generated in `TestMain`; covers the full admission flow.
+
+Coverage gate: `make test-coverage-check` enforces 100% coverage. Lines that genuinely cannot be tested (live Redis required, transient API errors, `json.Marshal` on well-typed structs) use `// coverage:ignore - <reason>`. Do not reach for this comment without first writing the test — it defeats the gate.
+
+Run the full gate: `make check` (lint + coverage + build).
 
 ## Build and CI
 
+| Target | What it does |
+|---|---|
+| `make check` | Full gate: golangci-lint + 100% coverage check + binary build |
+| `make test` | Run tests with envtest |
+| `make test-coverage` | Run tests, produce `coverage.out` |
+| `make test-coverage-check` | Enforce 100% coverage via `scripts/check-coverage.sh` |
+| `make build` | Build `bin/ballastd` |
+| `make lint` | Run golangci-lint |
+| `make lint-fix` | Auto-fix lint issues |
+| `make fmt` | Run goimports |
+| `make manifests` | Regenerate CRD YAML, RBAC, and webhook manifests from kubebuilder markers |
+| `make generate` | Regenerate DeepCopy methods |
+| `make tools` | Install goimports |
+| `make setup-hooks` | Install pre-commit hook (`scripts/pre-commit`) |
+
+### GitHub Actions
+
+| Workflow | Triggers | What it does |
+|---|---|---|
+| `ci.yml` | PR + main push | Parallel test / lint / build; uploads `coverage.filtered.out` to Codecov |
+| `pr-images.yml` | PR push | Builds `ghcr.io/tight-line/ballast:pr-<n>-<sha>` and comments on the PR |
+| `release.yml` | Tag push (`v*`) | Builds `ghcr.io/tight-line/ballast:<tag>` + `:latest`; packages and publishes `ballast-<ver>.tgz` to the Helm repo via chart-releaser |
+| `snyk.yml` | PR + main + weekly | Dependency vulnerability scan (high+ severity) |
+| `sonar.yml` | PR + main | SonarCloud static analysis |
+
+### Release workflow
+
+Run `scripts/make-tag <version>` (e.g. `scripts/make-tag 0.1.0`) to cut a release. The script:
+1. Runs `make check`
+2. Bumps `charts/ballast/Chart.yaml` version and `appVersion`
+3. Moves the `[Unreleased]` CHANGELOG section to `[<version>] - <date>`
+4. Commits and tags `v<version>`
+
+Then `git push origin main v<version>` triggers `release.yml`, which:
+- Builds and pushes `ghcr.io/tight-line/ballast:v<version>` and `:latest` (multi-arch: amd64 + arm64)
+- Runs `helm dependency update` then `helm/chart-releaser-action` to package `ballast-<version>.tgz`, upload it as a GitHub Release asset, and update `index.yaml` on the `gh-pages` branch
+
+The Helm repo (`https://tight-line.github.io/ballast`) is served from the `gh-pages` branch; GitHub Pages must be enabled on the repository pointing to that branch.
+
+### PR image workflow
+
+On every PR push `pr-images.yml` builds and pushes:
+
+```
+ghcr.io/tight-line/ballast:pr-<PR_NUMBER>-<SHORT_SHA>
+```
+
+The workflow comments the tag on the PR with a ready-to-paste Helm override. Images expire approximately 15 days after the PR closes.
+
+```yaml
+# Helm values override to use a PR image
+image:
+  repository: ghcr.io/tight-line/ballast
+  tag: "pr-42-abc1234"
+```
+
 ## Coding Standards
+
+- **Coverage first.** Write a test before reaching for `// coverage:ignore - <reason>`. Use the ignore comment only when testing is genuinely impossible (live Redis, transient API errors, `json.Marshal` on a struct that cannot fail).
+- **Logging.** Use `ctrl.LoggerFrom(ctx)` inside reconcile loops. Use `logger.New(component, level, format)` at startup. Suppressed-by-kill-switch actions log at `warn` with `kill_switch: true`. Dry-run actions log at `info` with `dry_run: true`.
+- **No direct API calls from controllers.** Read from the controller-runtime cache. Only the `store` and `plugin` packages call external services directly.
+- **Annotation validation.** Call `validation.ValidateAnnotations` before acting on any annotation combination.
+- **Imports.** `goimports` with local prefix `github.com/tight-line/ballast` (see `.golangci.yml`). Run `make fmt` before committing.
 
 ## Important: Never Edit These (Auto-Generated)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,98 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+### Added
+
+**Operator core**
+
+- `ballastd` binary: kubebuilder-managed operator with leader election, health/readiness probes, and structured logging
+- Per-component log levels (`--log-level`, `--log-level-webhook`, `--log-level-watcher`, `--log-level-collector`, `--log-level-adjuster`) and format selection (`--log-format json|text`)
+- Kill switch: creating the `ballast-kill-switch` ConfigMap in the operator namespace halts all mutation and resize activity without a restart; `BallastConfig.spec.suspended: true` provides the same effect in a GitOps-friendly way
+- Independent dry-run flags: `--dry-run-measure`, `--dry-run-apply`, `--dry-run-resize`; each logs what would have happened at `info` level with `dry_run: true`
+
+**CRD types**
+
+- `BallastConfig` (cluster-scoped singleton): `identityLabels`, `orphanTTL`, `retentionWindow`, `suspended`
+- `MetricsSource` (cluster-scoped): names a metrics plugin type and its poll configuration (`pollInterval`, `reservoirSize`)
+- `ClusterResourcePolicy` (cluster-scoped): full selector (kinds, namespace include/exclude regex, annotation patterns, `labelSelector`), metrics slice, readiness thresholds, and resize behaviors
+- `ResourcePolicy` (namespace-scoped): identical spec to `ClusterResourcePolicy`; always overrides any `ClusterResourcePolicy` match
+- `WorkloadProfile` (cluster-scoped, status subresource): accumulates per-container usage statistics and resource recommendations; tracks `meetsThreshold`, `activeWorkloads`, and Ready/Orphaned conditions
+
+**Workload identity and annotation contract**
+
+- Identity tuple: pods are grouped into `WorkloadProfile` objects by a configurable set of label keys (`BallastConfig.spec.identityLabels`); the profile name is derived from the sorted label values
+- Opt-in annotations: `measure`, `apply`, `resize`, `autoresize` under the `ballast.tightlinesoftware.com/` prefix
+- `autoresize` progressive mode: starts in measure-only mode, then automatically activates apply + resize once the readiness threshold is met
+- Annotation combination validation enforced at admission time with descriptive rejection messages
+
+**WorkloadWatcher controller**
+
+- Creates `WorkloadProfile` objects when the first opted-in pod is seen; sets `tupleLabels` in status
+- Stamps `ballast.tightlinesoftware.com/profile-ref` on pods for downstream controllers
+- Tracks `activeWorkloads`; sets `Orphaned` condition when count reaches zero
+- Orphan TTL: purges all Redis time-series keys and deletes the `WorkloadProfile` after the configured `orphanTTL` elapses
+
+**MetricsCollector controller**
+
+- Polls the configured metrics plugin on a timer derived from the matched policy's `MetricsSource.pollInterval`
+- Writes per-container CPU and memory samples into Redis sorted sets keyed by identity tuple hash, container name, and resource
+- Enforces retention window (`BallastConfig.spec.retentionWindow`) and per-key reservoir cap (`MetricsSource.spec.config.reservoirSize`)
+- Computes p50/p95/p99/max/mean/stddev/CV from the accumulated sample window
+- Evaluates readiness: `minDataPoints`, `minTimeSpan`, and `maxCV` must all pass
+- Writes computed statistics and resource recommendations to `WorkloadProfile` status
+
+**Admission webhook**
+
+- Mutating webhook for pod CREATE; registered at `/mutate-v1-pod`; `failurePolicy: Fail`
+- Patches container `resources.requests` and `resources.limits` at admission time when the matching `WorkloadProfile` is ready
+- Stamps `ballast.tightlinesoftware.com/policy-ref` on admitted pods
+- Progressive `autoresize` resolution: reads `WorkloadProfile.meetsThreshold` at admission time to decide whether to apply
+
+**ResourceAdjuster controller**
+
+- Watches `WorkloadProfile` status changes and runs on a periodic requeue timer (default 15 minutes)
+- Computes drift between current container resource values and profile recommendations
+- Threshold lookup follows a coalesce chain: per-resource field override → resize default → global default (20%)
+- Bounds each adjustment to `maxChangePerCycle` (default 50%) per cycle to avoid sudden large changes
+- Issues in-place pod resize patches via the Kubernetes resize subresource (requires Kubernetes 1.35+)
+- On infeasible resize (node pressure): emits a Kubernetes Event and stamps `ballast.tightlinesoftware.com/resize-blocked` annotation; retries on next cycle
+
+**Metrics plugin system**
+
+- `MetricsPlugin` interface with global registry; plugins self-register via `init()`
+- Built-in `kubernetesMetrics` plugin: calls the in-cluster metrics API (`metrics.k8s.io/v1beta1`); returns current CPU, memory, and ephemeral-storage usage for all regular containers
+- Token-bucket rate limiter (configurable RPS) shared across concurrent polls
+- Exponential backoff (base 1s, configurable ceiling, default 5 minutes) on API errors; caller skips the cycle while in backoff
+
+**Redis/Valkey storage layer**
+
+- `Client` interface over go-redis/v9; tests use miniredis for isolation
+- Deterministic `TupleHash` (SHA-256 prefix of sorted `key=value` pairs) for stable, map-order-independent keys
+- Sorted-set time-series operations: `AddSample`, `QueryWindow`, `ExpireOlderThan`, `EnforceReservoirCap`, `SampleCount`, `TimeRange`, `DeleteKey`
+- `AllKeysForHash` for full-profile Redis cleanup on orphan deletion
+
+**Policy resolution**
+
+- `Resolver` evaluates all `ClusterResourcePolicy` and `ResourcePolicy` objects from the controller-runtime cache
+- Namespace selectors support both exact-match strings and `/regex/` patterns; include and exclude lists; both-match = excluded with a `warn` log
+- Annotation selectors support the same exact-match and `/regex/` syntax
+- Standard `metav1.LabelSelector` evaluation via `k8s.io/apimachinery/pkg/labels`
+- Precedence: `ResourcePolicy` beats `ClusterResourcePolicy`; within the same class, higher `priority` wins; ties break alphabetically
+
+**Helm chart**
+
+- `charts/ballast/` chart with `bitnami/valkey` as an optional dependency (`valkey.enabled: true` by default)
+- cert-manager TLS integration: self-signed `Issuer` + `Certificate`; cert-manager injects `caBundle` into `MutatingWebhookConfiguration` automatically
+- Full Helm values for logging levels, dry-run flags, `BallastConfig` parameters, Redis endpoint, and image coordinates
+- RBAC: `ClusterRole` with exact permissions for all Ballast CRDs, pod get/list/watch/patch (resize), ConfigMap get/watch (kill switch), and Event create
+- CRD manifests bundled in `charts/ballast/crds/` for automatic install/upgrade
+
+**CI/CD**
+
+- `ci.yml`: parallel test / lint / build on every PR and main push; Codecov upload
+- `pr-images.yml`: builds `ghcr.io/tight-line/ballast:pr-<n>-<sha>` on every PR push; posts image tag and Helm override to the PR as a comment
+- `snyk.yml`: dependency vulnerability scan (high+ severity) on PRs, main, and weekly
+- `sonar.yml`: SonarCloud static analysis on PRs and main
+- Pre-commit hook (`scripts/pre-commit`): `goimports` format check + golangci-lint
+- 100% test coverage gate via `scripts/check-coverage.sh`; `// coverage:ignore - <reason>` required for genuinely untestable lines

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -311,9 +311,9 @@ _`make check` passing is the gate. If a test cluster with metrics-server is avai
     3. Deletes the `WorkloadProfile` object
   - envtest-based tests covering: create, increment, decrement, orphan transition, orphan TTL deletion, Redis key cleanup, kill switch suppression
 
-### Key files (fill in after complete)
+### Key files
 
-- `internal/controller/workloadwatcher/controller.go`
+- `internal/controller/workloadwatcher/controller.go` — `PodReconciler` (pod CREATE/DELETE) and `ProfileReconciler` (orphan TTL cleanup); exported `ExtractTupleLabels` and `ProfileName` used by webhook
 - `internal/controller/workloadwatcher/controller_test.go`
 
 ### User testing instructions
@@ -348,11 +348,11 @@ _Deploy to a test cluster with a pod carrying the `measure` annotation. Confirm 
   - `ComputeRecommendation(stats Stats, metric MetricConfig) resource.Quantity`
 - envtest + miniredis tests
 
-### Key files (fill in after complete)
+### Key files
 
-- `internal/controller/metricscollector/controller.go`
+- `internal/controller/metricscollector/controller.go` — `Reconciler`; `Setup(mgr, ks, sc, dryRunMeasure)` entry point; full poll-write-query-evaluate-update cycle
 - `internal/controller/metricscollector/controller_test.go`
-- `internal/stats/aggregator.go`
+- `internal/stats/aggregator.go` — `EvaluateReadiness(Stats, firstMs, lastMs, ReadinessConfig) bool`; `ComputeRecommendation(Stats, MetricConfig) (resource.Quantity, error)`
 - `internal/stats/aggregator_test.go`
 
 ### User testing instructions
@@ -404,7 +404,7 @@ _Deploy to test cluster with cert-manager. Create a pod with `ballast.tightlines
 
 ## Phase 10 — ResourceAdjuster Controller
 
-**Status:** `[~]`
+**Status:** `[x]`
 **Depends on:** Phases 3, 4, 7, 8, 9
 **PR:** https://github.com/Tight-Line/ballast/pull/13
 
@@ -426,9 +426,9 @@ Pod eviction is out of scope for Ballast — delegated to [Kubernetes Deschedule
   - **Kill switch:** suppresses all action
   - envtest tests: drift detection, resize success, resize blocked, autoresize threshold flip, dry-run, kill switch
 
-### Key files (fill in after complete)
+### Key files
 
-- `internal/controller/resourceadjuster/controller.go`
+- `internal/controller/resourceadjuster/controller.go` — `Reconciler`; `Setup(mgr, ks, dryRunResize)` entry point; exported utilities: `ExceedsDrift`, `CapChange`, `ResolveFieldThreshold`, `ParseResizeInterval`
 - `internal/controller/resourceadjuster/controller_test.go`
 
 ### User testing instructions
@@ -472,15 +472,15 @@ _Deploy to test cluster with a pod carrying `resize` annotation and a ready prof
 
 `helm lint` must pass. Smoke test: `helm template . | kubectl apply --dry-run=client -f -` produces no errors.
 
-### Key files (fill in after complete)
+### Key files
 
-- `charts/ballast/Chart.yaml`
-- `charts/ballast/values.yaml`
-- `charts/ballast/templates/deployment.yaml`
-- `charts/ballast/templates/clusterrole.yaml`
-- `charts/ballast/templates/mutatingwebhookconfiguration.yaml`
-- `charts/ballast/templates/ballastconfig.yaml`
-- `charts/ballast/crds/`
+- `charts/ballast/Chart.yaml` — chart metadata; `bitnami/valkey` dependency with `condition: valkey.enabled`
+- `charts/ballast/values.yaml` — all configurable settings: image, logging levels, dry-run flags, `ballastConfig.*`, `valkey.*`, `store.endpoint`, `certManager.enabled`
+- `charts/ballast/templates/deployment.yaml` — operator deployment; mounts cert Secret; translates all values to CLI flags
+- `charts/ballast/templates/clusterrole.yaml` — exact RBAC: all Ballast CRDs, pod patch, ConfigMap watch, Event create
+- `charts/ballast/templates/mutatingwebhookconfiguration.yaml` — `failurePolicy: Fail`; cert-manager `caBundle` injection annotation
+- `charts/ballast/templates/ballastconfig.yaml` — creates the `BallastConfig` singleton from values
+- `charts/ballast/crds/` — bundled CRD manifests (copied from `config/crd/bases/` at release)
 
 ### User testing instructions
 
@@ -490,18 +490,27 @@ _Install chart into a kind cluster with cert-manager pre-installed. Confirm oper
 
 ## Phase 12 — Polish & Release Readiness
 
-**Status:** `[ ]`
+**Status:** `[x]`
 **Depends on:** all prior phases
-**PR:** —
+**PR:** https://github.com/Tight-Line/ballast/pull/17
 
 ### What to build
 
-- `AGENTS.md` complete: all file locations, key functions, build commands, coding standards, testing workflow, PR image workflow, provider development guide
+- `AGENTS.md` complete: all file locations, key functions, build commands, coding standards, testing workflow, PR image workflow, release workflow, provider development guide
 - `README.md`: prerequisites (cert-manager, Kubernetes 1.35+, metrics-server), Helm quickstart, first annotation walkthrough, verifying a `WorkloadProfile`, kill switch usage
 - `CHANGELOG.md` `[Unreleased]` section fully populated
+- `.github/workflows/release.yml`: triggers on `v*` tag push; builds and pushes `ghcr.io/tight-line/ballast:<tag>` + `:latest` (multi-arch); packages `ballast-<ver>.tgz` via chart-releaser and publishes to `gh-pages` Helm repo
 - Verify `.github/workflows/pr-images.yml` produces correct image tags end-to-end
 - `make check` clean on main branch
 - This plan updated with all key-file entries filled in
+
+### Key files
+
+- `AGENTS.md` — complete agent guide: file index, architecture, CRD types, controller descriptions, plugin interface, Redis data model, testing strategy, build/CI, coding standards, PR image + release workflow, provider development guide
+- `README.md` — project overview, prerequisites, installation, WorkloadProfile identity, annotation contract, verifying a WorkloadProfile, kill switch, webhook TLS, dry-run mode, development workflow
+- `CHANGELOG.md` — `[Unreleased]` section populated with all features from phases 1–11
+- `.github/workflows/release.yml` — tag-triggered release: multi-arch container image + Helm chart tarball via chart-releaser
+- `IMPLEMENTATION_PLAN.md` — this file; all key-file entries filled in; Phase 10 status corrected to `[x]`
 
 ### User testing instructions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Workloads opt in with annotations on their pod templates. Ballast observes real 
 2. **Apply** — patch resource requests and limits at admission time when a pod is created.
 3. **Resize** — adjust resources on running pods via the Kubernetes in-place resize API (1.35+).
 
-`autoresize` starts in measure-only mode and automatically activates apply and resize once enough history has been collected.
+`autoresize` is shorthand for all three: it enables measure, apply, and resize with a single annotation. Nothing is applied or resized until the `WorkloadProfile` meets its readiness threshold — that is normal behavior for any resize-enabled workload.
 
 Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](https://github.com/kubernetes-sigs/descheduler) — see the Annotation Contract section for details.
 
@@ -33,7 +33,7 @@ Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](http
 | 9 | Admission webhook | Complete |
 | 10 | ResourceAdjuster controller | Complete |
 | 11 | Helm chart | Complete |
-| 12 | Polish and release readiness | Not started |
+| 12 | Polish and release readiness | Complete |
 
 ## Prerequisites
 
@@ -108,7 +108,7 @@ Add these annotations to your pod template specs to enroll workloads. Ballast ne
 | `ballast.tightlinesoftware.com/measure: "true"` | Collect metrics; required for any other behavior |
 | `ballast.tightlinesoftware.com/apply: "true"` | Patch requests/limits at admission time; requires `measure` |
 | `ballast.tightlinesoftware.com/resize: "true"` | Adjust resources on running pods via in-place resize; requires `apply` |
-| `ballast.tightlinesoftware.com/autoresize: "true"` | Progressive: measure-only until history threshold met, then `apply` + `resize` |
+| `ballast.tightlinesoftware.com/autoresize: "true"` | Shorthand for `measure` + `apply` + `resize`; mutually exclusive with `apply` and `resize` |
 
 **Pod eviction** is deliberately out of scope for Ballast. Ballast keeps resource requests and limits accurate; cluster rebalancing based on those corrected values is best handled by [Kubernetes Descheduler](https://github.com/kubernetes-sigs/descheduler) (specifically its `LowNodeUtilization` strategy). This is a clean division of labor: Ballast gets the weight right, Descheduler decides where pods should sit.
 


### PR DESCRIPTION
## Summary

- **AGENTS.md**: complete agent guide — file index, architecture, all CRD types, controller descriptions, plugin interface, Redis data model, testing strategy, build/CI, coding standards, PR image workflow, release workflow, and provider development guide
- **CHANGELOG.md**: `[Unreleased]` section populated with all features from phases 1–11
- **README.md**: fix `autoresize` description (it is shorthand for `measure + apply + resize`, not a "progressive mode"); update implementation status table to mark Phase 12 complete
- **`.github/workflows/release.yml`**: tag-triggered release — builds `ghcr.io/tight-line/ballast:<tag>` + `:latest` (multi-arch amd64/arm64) and packages/publishes `ballast-<ver>.tgz` to the `gh-pages` Helm repo via `helm/chart-releaser-action`
- **IMPLEMENTATION_PLAN.md**: fill in key-file descriptions for phases 7, 8, 10, 11; correct Phase 10 status to `[x]`; add Phase 12 key files; mark Phase 12 complete

## Test plan

- [ ] Confirm CI passes (lint, coverage, build)
- [ ] Review AGENTS.md for accuracy and completeness
- [ ] Review CHANGELOG.md [Unreleased] entries against merged PRs
- [ ] Confirm README autoresize annotation table row reads correctly
- [ ] After merge: run `scripts/make-tag 0.1.0` and push tag; confirm `release.yml` triggers, image appears in GHCR as `ballast:v0.1.0`, and Helm chart tarball appears as a GitHub Release asset
- [ ] Confirm `helm repo add tight-line https://tight-line.github.io/ballast && helm search repo tight-line/ballast` returns the chart (requires GitHub Pages enabled on `gh-pages` branch)