### PR TITLE
Release workflow: amd64-first builds, fix Helm repo add, prep for v0.1.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,24 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
 
-      - name: Build and push (multi-arch)
+      # Build amd64 first for fast availability (native build, ~2 min)
+      - name: Build and push ballast (amd64)
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            VERSION=${{ steps.meta.outputs.VERSION }}
+          tags: |
+            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:${{ steps.meta.outputs.TAG }}
+            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:latest
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # Then build multi-arch (updates tags in-place with manifest)
+      - name: Build and push ballast (multi-arch)
         uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Release workflow: build and push amd64 image first for fast availability, then follow with multi-arch (amd64 + arm64) manifest
+- Release workflow: add `helm repo add` step so chart dependency update succeeds in CI
+- Helm install instructions: use `ballast` as the repo alias (`helm repo add ballast ...`) instead of `tight-line`
+
 ## [0.1.0] - 2026-06-28
 
 ### Added


### PR DESCRIPTION
## Summary

- Build and push amd64 image first (~2 min, immediately pullable), then follow with the full multi-arch manifest — matches the pattern used in gatekeeper
- Add `helm repo add valkey` step before `helm dependency update` so chart packaging no longer fails with "no repository definition" error
- Use `ballast` as the Helm repo alias in install instructions (`helm repo add ballast https://tight-line.github.io/ballast`)
- Add [Unreleased] CHANGELOG entries so `scripts/make-tag 0.1.1` passes without complaint

## Test plan

- [x] Merge and tag `0.1.1` — verify `ghcr.io/tight-line/ballast:v0.1.1` is available quickly (amd64) before multi-arch completes
- [x] Confirm Helm chart packaging step passes (was failing with missing repo definition on v0.1.0)