### PR TITLE
Treat absent identity labels as placeholders instead of skipping pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Pods opted into ballast (via annotation) that are missing one or more identity labels are no longer silently skipped. Absent label keys now contribute a human-readable placeholder to the WorkloadProfile name (e.g. `app.kubernetes.io/component` absent → `nocomponent`), so the profile is still created and measurements proceed.
+
 ## [0.1.2] - 2026-06-28
 
 - Fix app version tagging so that Helm chart defaults match actual git tags and container image tags

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ labels:
   ballast.tightlinesoftware.com/profile: prod
 ```
 
-Now `(billing, api, prod)` and `(billing, api, dev)` are measured independently. Pods without the label are simply excluded from measurement — they produce no profile.
+Now `(billing, api, prod)` and `(billing, api, dev)` are measured independently. Pods without the `ballast.tightlinesoftware.com/profile` label get a placeholder value in the profile name (`noprofile`) rather than being skipped, so opted-in pods always produce a profile.
 
 > **Changing `identityLabels` wipes your operational history.** It redefines what constitutes a workload identity, so all existing `WorkloadProfile` objects are renamed and their accumulated Redis history is orphaned. Ballast starts fresh from zero samples. Plan your tuple before enrolling workloads.
 
@@ -141,7 +141,7 @@ Once a pod with the `measure` annotation is running, Ballast creates a `Workload
 
 ```bash
 kubectl get workloadprofiles
-kubectl describe workloadprofile billing--prod
+kubectl describe workloadprofile billing--api--prod
 ```
 
 The profile status shows accumulated usage statistics and recommendations once the readiness threshold is met (default: 500 samples collected over 24 hours):

--- a/internal/controller/metricscollector/controller_test.go
+++ b/internal/controller/metricscollector/controller_test.go
@@ -156,7 +156,7 @@ func defaultPolicy() *ballastv1.ClusterResourcePolicy {
 
 func defaultProfile(tupleLabels map[string]string) *ballastv1.WorkloadProfile {
 	return &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 		Status: ballastv1.WorkloadProfileStatus{
 			TupleLabels: tupleLabels,
 		},
@@ -194,7 +194,7 @@ func TestReconcile_NoBallastConfig(t *testing.T) {
 	_, sc := newMiniredisClient(t)
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -210,7 +210,7 @@ func TestReconcile_NoMatchingPolicy(t *testing.T) {
 	_, sc := newMiniredisClient(t)
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -235,7 +235,7 @@ func TestReconcile_KillSwitchActive(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, activeKS(t), false, p)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestReconcile_DryRun(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), true, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -281,7 +281,7 @@ func TestReconcile_DryRun(t *testing.T) {
 
 	// Status not updated.
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
 	}
 	if len(got.Status.Containers) != 0 {
@@ -308,7 +308,7 @@ func TestReconcile_MetricsSourceNotFound(t *testing.T) {
 	_, sc := newMiniredisClient(t)
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, nil)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -339,7 +339,7 @@ func TestReconcile_CollectAndUpdate(t *testing.T) {
 	}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestReconcile_CollectAndUpdate(t *testing.T) {
 
 	// WorkloadProfile status should be updated.
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
 	}
 	if len(got.Status.Containers) == 0 {
@@ -404,13 +404,13 @@ func TestReconcile_ReadinessNotMet(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
 	}
 	if got.Status.MeetsThreshold {
@@ -442,13 +442,13 @@ func TestReconcile_ReadinessMet_RecommendationsPopulated(t *testing.T) {
 	}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
 	}
 
@@ -493,13 +493,13 @@ func TestReconcile_ExistingContainersPreserved(t *testing.T) {
 	p := &mockPlugin{typeName: "kubernetesMetrics", samples: nil} // no new samples
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("Reconcile: %v", err)
 	}
 
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
 	}
 	// The app container should still appear (merged from existing status).
@@ -532,7 +532,7 @@ func TestReconcile_PluginNotFound(t *testing.T) {
 	p := &mockPlugin{typeName: "kubernetesMetrics"} // type mismatch with source
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -552,7 +552,7 @@ func TestReconcile_FetchStatsError(t *testing.T) {
 	p := &mockPlugin{typeName: "kubernetesMetrics", err: errors.New("metrics unavailable")}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -587,12 +587,12 @@ func TestReconcile_BadAggregation(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	if len(got.Status.Containers) > 0 {
@@ -621,7 +621,7 @@ func TestReconcile_InvalidRetentionWindow(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -650,7 +650,7 @@ func TestReconcile_ShortPollInterval(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	result, err := reconcileProfile(t, r, "app--web")
+	result, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -688,12 +688,12 @@ func TestReconcile_MemoryMetric(t *testing.T) {
 	}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	if !got.Status.MeetsThreshold {
@@ -731,12 +731,12 @@ func TestReconcile_DuplicateContainerMerge(t *testing.T) {
 	}}
 	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
 
-	_, err := reconcileProfile(t, r, "app--web")
+	_, err := reconcileProfile(t, r, "web")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	var got ballastv1.WorkloadProfile
-	if err := fc.Get(ctx, types.NamespacedName{Name: "app--web"}, &got); err != nil {
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
 		t.Fatalf("Get: %v", err)
 	}
 	found := false
@@ -797,7 +797,7 @@ func TestReconciler_SetupWithManager(t *testing.T) {
 
 	// Create a WorkloadProfile — the controller should reconcile it without error.
 	profile := &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 	}
 	if err := c.Create(ctx, profile); err != nil {
 		t.Fatalf("create WorkloadProfile: %v", err)
@@ -805,7 +805,7 @@ func TestReconciler_SetupWithManager(t *testing.T) {
 
 	// Verify the profile is reachable — the controller reconciles but returns early
 	// (no BallastConfig) without error.
-	waitForProfileExists(t, ctx, c, "app--web")
+	waitForProfileExists(t, ctx, c, "web")
 }
 
 func waitForProfileExists(t *testing.T, ctx context.Context, c client.Client, name string) {

--- a/internal/controller/resourceadjuster/controller_test.go
+++ b/internal/controller/resourceadjuster/controller_test.go
@@ -137,7 +137,7 @@ func noResizePolicy() *ballastv1.ClusterResourcePolicy {
 // readyProfile returns a WorkloadProfile with MeetsThreshold=true and one container recommendation.
 func readyProfile(cpuRequest, cpuLimit string) *ballastv1.WorkloadProfile {
 	return &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--prod"},
+		ObjectMeta: metav1.ObjectMeta{Name: "prod"},
 		Status: ballastv1.WorkloadProfileStatus{
 			TupleLabels:    map[string]string{"app": "app", "env": "prod"},
 			MeetsThreshold: true,
@@ -161,7 +161,7 @@ func resizePod(cpuRequest, cpuLimit string) *corev1.Pod {
 			Namespace: "default",
 			Annotations: map[string]string{
 				workloadwatcher.AnnotationResize:     "true",
-				workloadwatcher.AnnotationProfileRef: "app--prod",
+				workloadwatcher.AnnotationProfileRef: "prod",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -624,7 +624,7 @@ func TestReconcile_NilContainerResources_HandledGracefully(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				workloadwatcher.AnnotationResize:     "true",
-				workloadwatcher.AnnotationProfileRef: "app--prod",
+				workloadwatcher.AnnotationProfileRef: "prod",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -687,7 +687,7 @@ func TestReconcile_PodNilAnnotations_BlockedAnnotationStamped(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				workloadwatcher.AnnotationResize:     "true",
-				workloadwatcher.AnnotationProfileRef: "app--prod",
+				workloadwatcher.AnnotationProfileRef: "prod",
 			},
 		},
 		Spec: corev1.PodSpec{
@@ -796,7 +796,7 @@ func TestReconcile_ApplyResize_NilResources_InitializedCorrectly(t *testing.T) {
 			Namespace: "default",
 			Annotations: map[string]string{
 				workloadwatcher.AnnotationResize:     "true",
-				workloadwatcher.AnnotationProfileRef: "app--prod",
+				workloadwatcher.AnnotationProfileRef: "prod",
 			},
 		},
 		Spec: corev1.PodSpec{

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -131,13 +131,7 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		return ctrl.Result{}, err // coverage:ignore - transient API error
 	}
 
-	tupleLabels, err := ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
-	if err != nil {
-		log.Info("pod missing required identity labels, skipping",
-			"pod", pod.Name, "namespace", pod.Namespace, "error", err.Error())
-		return ctrl.Result{}, nil
-	}
-
+	tupleLabels := ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
 	profName := ProfileName(tupleLabels)
 
 	if err := r.ensureProfile(ctx, profName, tupleLabels); err != nil { // coverage:ignore - transient API error
@@ -330,27 +324,47 @@ func (r *ProfileReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 // ExtractTupleLabels returns a map of identityLabel key -> pod label value.
-// Returns an error listing any keys absent from podLabels.
-func ExtractTupleLabels(podLabels map[string]string, identityLabels []string) (map[string]string, error) {
+// Keys absent from podLabels are assigned a placeholder derived from the key
+// (e.g. "app.kubernetes.io/component" -> "nocomponent") so the WorkloadProfile
+// name remains meaningful without a real value.
+func ExtractTupleLabels(podLabels map[string]string, identityLabels []string) map[string]string {
 	out := make(map[string]string, len(identityLabels))
-	var missing []string
 	for _, k := range identityLabels {
 		v, ok := podLabels[k]
 		if !ok {
-			missing = append(missing, k)
-			continue
+			v = missingLabelPlaceholder(k)
 		}
 		out[k] = v
 	}
-	if len(missing) > 0 {
-		return nil, fmt.Errorf("missing identity labels: %s", strings.Join(missing, ", "))
+	return out
+}
+
+// missingLabelPlaceholder derives a human-readable sentinel for an absent label.
+// It takes the segment after the last '/', strips non-letter characters, lowercases
+// the result, and prepends "no".
+//
+// Examples:
+//
+//	"app.kubernetes.io/component" -> "nocomponent"
+//	"foo.bar.baz"                 -> "nofoobarbaz"
+//	"app"                         -> "noapp"
+func missingLabelPlaceholder(key string) string {
+	seg := key
+	if i := strings.LastIndexByte(key, '/'); i >= 0 {
+		seg = key[i+1:]
 	}
-	return out, nil
+	clean := strings.Map(func(r rune) rune {
+		if unicode.IsLetter(r) {
+			return unicode.ToLower(r)
+		}
+		return -1
+	}, seg)
+	return "no" + clean
 }
 
 // ProfileName derives a deterministic Kubernetes-safe name from a label tuple.
-// Keys are sorted alphabetically and joined with values as "key--value" pairs
-// separated by "--". Each segment is sanitized to lowercase alphanumeric-and-dash.
+// Keys are sorted alphabetically; only their values are joined with "--".
+// Each value is sanitized to lowercase alphanumeric-and-dash.
 func ProfileName(tupleLabels map[string]string) string {
 	keys := make([]string, 0, len(tupleLabels))
 	for k := range tupleLabels {
@@ -360,7 +374,7 @@ func ProfileName(tupleLabels map[string]string) string {
 
 	var parts []string
 	for _, k := range keys {
-		parts = append(parts, sanitizeName(k), sanitizeName(tupleLabels[k]))
+		parts = append(parts, sanitizeName(tupleLabels[k]))
 	}
 	name := strings.Join(parts, "--")
 	if len(name) > 253 { // coverage:ignore - triggered only with extremely long label values

--- a/internal/controller/workloadwatcher/controller_test.go
+++ b/internal/controller/workloadwatcher/controller_test.go
@@ -129,7 +129,7 @@ func TestPodReconciler_NewPod(t *testing.T) {
 
 	// WorkloadProfile should be created.
 	var profile ballastv1.WorkloadProfile
-	profName := "app--web"
+	profName := "web"
 	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &profile); err != nil {
 		t.Fatalf("Get WorkloadProfile %q: %v", profName, err)
 	}
@@ -165,7 +165,7 @@ func TestPodReconciler_NewPod(t *testing.T) {
 func TestPodReconciler_AlreadyProcessed(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -201,15 +201,17 @@ func TestPodReconciler_AlreadyProcessed(t *testing.T) {
 	}
 }
 
-func TestPodReconciler_MissingIdentityLabels(t *testing.T) {
+func TestPodReconciler_AbsentIdentityLabelUsesPlaceholder(t *testing.T) {
 	ctx := context.Background()
 
+	// Pod is opted in but missing the "app" identity label entirely.
+	// The reconciler should create a profile using the "noapp" placeholder.
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "web-abc",
 			Namespace:   "default",
 			Annotations: map[string]string{workloadwatcher.AnnotationMeasure: "true"},
-			Labels:      map[string]string{"tier": "backend"}, // "app" label missing
+			Labels:      map[string]string{"tier": "backend"},
 		},
 	}
 	fc := newFakeClient(defaultBallastConfig(), pod)
@@ -221,8 +223,11 @@ func TestPodReconciler_MissingIdentityLabels(t *testing.T) {
 	if err := fc.List(ctx, &list); err != nil {
 		t.Fatalf("List WorkloadProfiles: %v", err)
 	}
-	if len(list.Items) != 0 {
-		t.Errorf("expected no WorkloadProfiles, got %d", len(list.Items))
+	if len(list.Items) != 1 {
+		t.Fatalf("expected 1 WorkloadProfile, got %d", len(list.Items))
+	}
+	if got := list.Items[0].Name; got != "noapp" {
+		t.Errorf("profile name = %q, want %q", got, "noapp")
 	}
 }
 
@@ -254,7 +259,7 @@ func TestPodReconciler_KillSwitchSuppresses(t *testing.T) {
 func TestPodReconciler_DeleteDecrement(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -316,7 +321,7 @@ func TestPodReconciler_DeleteDecrement(t *testing.T) {
 func TestPodReconciler_DeleteOrphanTransition(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -365,7 +370,7 @@ func TestPodReconciler_DeleteOrphanTransition(t *testing.T) {
 func TestPodReconciler_DeleteKillSwitchAllowsDecrement(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -408,7 +413,7 @@ func TestPodReconciler_DeleteKillSwitchAllowsDecrement(t *testing.T) {
 func TestPodReconciler_NewPodClearsOrphan(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -479,7 +484,7 @@ func TestPodReconciler_BallastConfigNotFound(t *testing.T) {
 func TestPodReconciler_RecoveryAddFinalizer(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
 	// Pod already has profile-ref (was previously processed) but our finalizer is missing.
 	pod := &corev1.Pod{
@@ -530,7 +535,7 @@ func TestPodReconciler_RecoveryAddFinalizer(t *testing.T) {
 func TestPodReconciler_DeleteNoFinalizer(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
 	// Pod is being deleted (held by a foreign finalizer) but lacks our finalizer.
 	pod := &corev1.Pod{
@@ -590,11 +595,69 @@ func TestPodReconciler_SpecialLabelChars(t *testing.T) {
 
 	reconcilePod(t, c, "default", "web-abc")
 
-	// "my_app.v2" sanitizes to "my-app-v2" → profile name "app--my-app-v2".
-	expectedName := "app--my-app-v2"
+	// "my_app.v2" sanitizes to "my-app-v2" → profile name "my-app-v2".
+	expectedName := "my-app-v2"
 	var profile ballastv1.WorkloadProfile
 	if err := fc.Get(ctx, types.NamespacedName{Name: expectedName}, &profile); err != nil {
 		t.Fatalf("Get WorkloadProfile %q: %v (sanitization of special chars may be wrong)", expectedName, err)
+	}
+}
+
+// -- ExtractTupleLabels unit tests --
+
+func TestExtractTupleLabels(t *testing.T) {
+	cases := []struct {
+		name           string
+		podLabels      map[string]string
+		identityLabels []string
+		want           map[string]string
+	}{
+		{
+			name:           "all labels present",
+			podLabels:      map[string]string{"app": "web", "tier": "frontend"},
+			identityLabels: []string{"app", "tier"},
+			want:           map[string]string{"app": "web", "tier": "frontend"},
+		},
+		{
+			name:           "absent label uses placeholder - bare key",
+			podLabels:      map[string]string{"tier": "backend"},
+			identityLabels: []string{"app"},
+			want:           map[string]string{"app": "noapp"},
+		},
+		{
+			name:           "absent label uses placeholder - namespaced key",
+			podLabels:      map[string]string{"app.kubernetes.io/name": "nginx"},
+			identityLabels: []string{"app.kubernetes.io/name", "app.kubernetes.io/component"},
+			want: map[string]string{
+				"app.kubernetes.io/name":      "nginx",
+				"app.kubernetes.io/component": "nocomponent",
+			},
+		},
+		{
+			name:           "absent label uses placeholder - dotted key no slash",
+			podLabels:      map[string]string{},
+			identityLabels: []string{"foo.bar.baz"},
+			want:           map[string]string{"foo.bar.baz": "nofoobarbaz"},
+		},
+		{
+			name:           "all labels absent",
+			podLabels:      map[string]string{},
+			identityLabels: []string{"app", "tier"},
+			want:           map[string]string{"app": "noapp", "tier": "notier"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := workloadwatcher.ExtractTupleLabels(tc.podLabels, tc.identityLabels)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %v, want %v", got, tc.want)
+			}
+			for k, wantV := range tc.want {
+				if got[k] != wantV {
+					t.Errorf("key %q: got %q, want %q", k, got[k], wantV)
+				}
+			}
+		})
 	}
 }
 
@@ -603,7 +666,7 @@ func TestPodReconciler_SpecialLabelChars(t *testing.T) {
 func TestProfileReconciler_NotOrphaned(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -629,7 +692,7 @@ func TestProfileReconciler_NotOrphaned(t *testing.T) {
 
 func TestProfileReconciler_OrphanTTLNotExpired(t *testing.T) {
 	orphanedAt := metav1.Now()
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
@@ -673,7 +736,7 @@ func TestProfileReconciler_OrphanTTLNotExpired(t *testing.T) {
 }
 
 func TestProfileReconciler_InvalidOrphanTTL(t *testing.T) {
-	profName := "app--web"
+	profName := "web"
 	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
 	cfg := &ballastv1.BallastConfig{
 		ObjectMeta: metav1.ObjectMeta{Name: "ballast"},
@@ -707,7 +770,7 @@ func TestProfileReconciler_InvalidOrphanTTL(t *testing.T) {
 func TestProfileReconciler_OrphanTTLExpired(t *testing.T) {
 	ctx := context.Background()
 
-	profName := "app--web"
+	profName := "web"
 	tupleLabels := map[string]string{"app": "web"}
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
@@ -794,7 +857,7 @@ func TestHasBallastAnnotationOrFinalizer(t *testing.T) {
 func TestProfileName_LongLabel(t *testing.T) {
 	ctx := context.Background()
 
-	// A value long enough that "app--<value>" would exceed 253 chars.
+	// A value long enough to exceed the 253-char profile name limit on its own.
 	longValue := strings.Repeat("a", 260)
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
@@ -822,7 +885,7 @@ func TestProfileName_LongLabel(t *testing.T) {
 }
 
 func TestProfileReconciler_RedisFailure(t *testing.T) {
-	profName := "app--web"
+	profName := "web"
 	tupleLabels := map[string]string{"app": "web"}
 	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
 	cfg := &ballastv1.BallastConfig{
@@ -926,11 +989,11 @@ func TestController_SetupWithManager(t *testing.T) {
 	}
 
 	// Wait for WorkloadProfile to appear.
-	waitForProfile(t, ctx, c, "app--web")
+	waitForProfile(t, ctx, c, "web")
 
 	// Verify activeWorkloads=1.
 	var profile ballastv1.WorkloadProfile
-	if err := c.Get(ctx, types.NamespacedName{Name: "app--web"}, &profile); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: "web"}, &profile); err != nil {
 		t.Fatalf("Get WorkloadProfile: %v", err)
 	}
 	if profile.Status.ActiveWorkloads != 1 {
@@ -941,7 +1004,7 @@ func TestController_SetupWithManager(t *testing.T) {
 	if err := c.Delete(ctx, pod); err != nil {
 		t.Fatalf("delete pod: %v", err)
 	}
-	waitForOrphaned(t, ctx, c, "app--web")
+	waitForOrphaned(t, ctx, c, "web")
 }
 
 func waitForProfile(t *testing.T, ctx context.Context, c client.Client, name string) {

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -156,10 +156,7 @@ func (m *PodMutator) lookupProfile(ctx context.Context, pod *corev1.Pod) (*balla
 		return nil, fmt.Errorf("getting BallastConfig: %w", err)
 	}
 
-	tupleLabels, err := workloadwatcher.ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
-	if err != nil {
-		return nil, fmt.Errorf("extracting tuple labels: %w", err)
-	}
+	tupleLabels := workloadwatcher.ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
 
 	var wp ballastv1.WorkloadProfile
 	if err := m.client.Get(ctx, types.NamespacedName{Name: workloadwatcher.ProfileName(tupleLabels)}, &wp); err != nil {

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -79,11 +79,11 @@ func defaultBallastConfig() *ballastv1.BallastConfig {
 	}
 }
 
-// readyProfile returns a WorkloadProfile named "app--web" (matching pod label app=web)
+// readyProfile returns a WorkloadProfile named "web" (matching pod label app=web)
 // with cpu+memory recommendations and meetsThreshold=true.
 func readyProfile() *ballastv1.WorkloadProfile {
 	return &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 		Status: ballastv1.WorkloadProfileStatus{
 			MeetsThreshold: true,
 			Containers: []ballastv1.ContainerProfile{
@@ -101,7 +101,7 @@ func readyProfile() *ballastv1.WorkloadProfile {
 
 func notReadyProfile() *ballastv1.WorkloadProfile {
 	return &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 		Status:     ballastv1.WorkloadProfileStatus{MeetsThreshold: false},
 	}
 }
@@ -408,7 +408,7 @@ func TestPodMutator_UnmatchedContainer(t *testing.T) {
 
 func TestPodMutator_EmptyRecommendationField(t *testing.T) {
 	profile := &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 		Status: ballastv1.WorkloadProfileStatus{
 			MeetsThreshold: true,
 			Containers: []ballastv1.ContainerProfile{
@@ -439,7 +439,7 @@ func TestPodMutator_EmptyRecommendationField(t *testing.T) {
 
 func TestPodMutator_InvalidQuantity(t *testing.T) {
 	profile := &ballastv1.WorkloadProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "app--web"},
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
 		Status: ballastv1.WorkloadProfileStatus{
 			MeetsThreshold: true,
 			Containers: []ballastv1.ContainerProfile{


### PR DESCRIPTION
## Summary

- Pods opted into ballast (via annotation) but missing one or more identity labels were previously silently skipped with a log warning. Since the annotation is the real opt-in gate, a missing label should not block measurement.
- `ExtractTupleLabels` now substitutes a deterministic placeholder for any absent key: take the segment after the last `/`, strip non-letter characters, lowercase, prepend `no`. Examples: `app.kubernetes.io/component` → `nocomponent`, `foo.bar.baz` → `nofoobarbaz`, `app` → `noapp`.
- `ProfileName` was also corrected: it now emits label values only (sorted by configured key order), not `key--value` pairs. This was a latent bug masked by short keys like `"app"` — with long keys like `app.kubernetes.io/name` the old format produced unreadable names.
- Error return removed from `ExtractTupleLabels` (and both call sites updated) since there is no longer an error case.

## Test plan

- [x] `make test-coverage-check` passes
- [x] `TestPodReconciler_AbsentIdentityLabelUsesPlaceholder` confirms profile `noapp` is created when the `app` label is absent
- [x] `TestExtractTupleLabels` table test covers all placeholder derivation cases (bare key, namespaced key, dotted key without slash, all absent)
- [ ] Verify against a real nginx deployment: pod with `app.kubernetes.io/name=nginx` but no `app.kubernetes.io/component` should produce a `WorkloadProfile` named `nginx--nocomponent`