### PR TITLE
Fix resize cooldown; demote noisy log messages to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **In-place resize now respects the configured interval.** The resource adjuster reconciles whenever the WorkloadProfile status is updated (every ~1 minute from the metrics collector), not just on its own timer. Without a cooldown check, every status update triggered a fresh resize even though the policy interval was set to 15 minutes. The adjuster now checks `ballast.tightlinesoftware.com/last-resize` on each pod and skips it if a resize was applied within the configured interval.
+
+### Changed
+
+- Demoted two high-frequency log messages from `Info` to `Debug` (`V(1)`): "resolved policy" (emitted by the policy resolver on every reconciliation) and "profile does not meet threshold, skipping resize" (emitted by the resource adjuster). Both are now suppressed unless the controller is started with `--zap-log-level=debug`.
+
 ## [0.1.4] - 2026-06-29
 
 ### Added

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -93,7 +93,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if !profile.Status.MeetsThreshold {
-		log.Info("profile does not meet threshold, skipping resize", "profile", profile.Name)
+		log.V(1).Info("profile does not meet threshold, skipping resize", "profile", profile.Name)
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
@@ -114,7 +114,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	for i := range pods {
-		if err := r.reconcilePod(ctx, &pods[i], &profile, resolved.Spec.Behaviors); err != nil { // coverage:ignore - transient API error
+		if err := r.reconcilePod(ctx, &pods[i], &profile, resolved.Spec.Behaviors, interval); err != nil { // coverage:ignore - transient API error
 			return ctrl.Result{}, err
 		}
 	}
@@ -153,8 +153,15 @@ func wantsResize(ann map[string]string) bool {
 }
 
 // reconcilePod evaluates drift for one pod and issues a resize if needed.
-func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile *ballastv1.WorkloadProfile, behaviors ballastv1.BehaviorConfig) error {
+func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile *ballastv1.WorkloadProfile, behaviors ballastv1.BehaviorConfig, interval time.Duration) error {
 	log := ctrl.LoggerFrom(ctx)
+
+	if last, ok := pod.Annotations[AnnotationLastResize]; ok {
+		if t, err := time.Parse(time.RFC3339, last); err == nil && time.Since(t) < interval {
+			log.V(1).Info("resize cooldown active, skipping", "pod", pod.Name, "namespace", pod.Namespace, "next_resize", t.Add(interval))
+			return nil
+		}
+	}
 
 	recsByName := containerRecsByName(profile)
 	adjustments := computeAdjustments(pod, recsByName, behaviors)

--- a/internal/controller/resourceadjuster/controller_test.go
+++ b/internal/controller/resourceadjuster/controller_test.go
@@ -403,6 +403,26 @@ func TestReconcile_ResizeSucceeds_LastResizeAnnotationStamped(t *testing.T) {
 	}
 }
 
+func TestReconcile_CooldownActive_ResizeSkipped(t *testing.T) {
+	// Pod was resized 5 minutes ago — within the 15m interval — so resize should be skipped.
+	profile := readyProfile("200m", "400m")
+	pod := resizePod("100m", "200m")
+	pod.Annotations[resourceadjuster.AnnotationLastResize] = time.Now().Add(-5 * time.Minute).UTC().Format(time.RFC3339)
+	fc := newFakeClient(profile, noResizePolicy(), pod)
+	r := resourceadjuster.New(fc, inactiveKS(t), false)
+	resizeCalled := false
+	r.ResizePod = func(_ context.Context, _ *corev1.Pod, _ []resourceadjuster.ContainerAdjustment) error {
+		resizeCalled = true
+		return nil
+	}
+	if _, err := doReconcile(t, r, profile.Name); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resizeCalled {
+		t.Error("resize should not be called when pod is within cooldown window")
+	}
+}
+
 func TestReconcile_RequeueInterval_FromPolicy(t *testing.T) {
 	policy := noResizePolicy()
 	policy.Spec.Behaviors.Resize.Interval = "5m"

--- a/internal/policy/resolver.go
+++ b/internal/policy/resolver.go
@@ -86,7 +86,7 @@ func (r *Resolver) Resolve(ctx context.Context, in Input) (*ResolvedPolicy, erro
 	})
 
 	best := matches[0]
-	r.log.Info("resolved policy",
+	r.log.V(1).Info("resolved policy",
 		"namespace", in.Namespace,
 		"ownerKind", in.OwnerKind,
 		"policy", best.name,


### PR DESCRIPTION
## Summary

- **Bug fix:** The resource adjuster reconciles on every WorkloadProfile status update (~1/min from the metrics collector), not just on its own requeue timer. Without a cooldown check, every status update triggered a resize regardless of the policy interval. The adjuster now reads `ballast.tightlinesoftware.com/last-resize` on each pod and skips it if a resize was applied within the configured interval.
- **Log noise:** Demoted "resolved policy" (policy resolver) and "profile does not meet threshold" (resource adjuster) from `Info` to `V(1)` (debug). Both fired on every reconciliation and added significant log noise in normal operation.

## Test plan

- [x] `make test-coverage-check` passes (96.6% on resourceadjuster, all packages green)
- [x] `TestReconcile_CooldownActive_ResizeSkipped` covers the new cooldown path
- [x] Verified in kind cluster: `last-resize` annotation appears on pod after first resize, subsequent reconciliations are skipped until interval elapses
- [x] "resolved policy" and "profile does not meet threshold" no longer appear at default log level