### PR TITLE
Phase 15: default policy, memory/ephemeral limits, and policy presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`p75` and `p90` aggregations.** `ClusterResourcePolicy` metric entries now accept `p75` and `p90` alongside the existing `p50`/`p95`/`p99`/`max`/`avg`. The stats engine computes both percentiles, the metrics collector publishes them on `WorkloadProfile` container usage stats, and the recommendation resolver maps them through. This unblocks sizing ephemeral storage at p90.
+
+- **Memory-limit and ephemeral-storage sizing in the default policy.** The default `ClusterResourcePolicy` now sets a memory limit at p99 with no headroom (a pod exceeding its production-observed peak is likely leaking and should be OOMKilled), which yields Burstable QoS. It also sizes ephemeral-storage request and limit at p90 and p99 from the `kubelet-summary` source. CPU limits remain intentionally omitted to avoid throttling.
+
+- **Per-metric `source` in the policy template.** Each metric entry can now name its own `MetricsSource`, falling back to the policy default when absent. This lets CPU/memory entries reference `kubernetes-metrics` and ephemeral-storage entries reference `kubelet-summary` within one policy object.
+
+- **Policy presets.** The chart ships a catalog of policy presets as Helm values overlays under `charts/ballast/presets/`. The built-in default in `values.yaml` is the `homogeneous-large-fleet` preset; `local-testing.yaml` is a fast-cycle overlay for kind clusters that `make helm-update-local` applies automatically. Select one at install time with `-f`; a later `-f` or `--set` deep-merges on top. See `charts/ballast/presets/README.md`.
+
+- **`TESTING.md`.** A local test loop walkthrough: deploy with the local-testing preset, install a workload with the autoresize annotation, then watch the profile become eligible and the pod get resized.
+
+### Changed
+
+- **Default request sizing moved from `p95 * headroom` to `avg * 1.25`** (= mean / 0.80 target utilization). For a large homogeneous fleet the aggregate pressure is predictable, so sizing requests at 80% of mean keeps nodes dense while leaving headroom for normal variation.
+
+- **Default sampling and readiness retuned for production cadence.** The `defaultMetricsSources` poll interval rose from 60s to 5m, and `defaultClusterResourcePolicy.readiness.minDataPoints` dropped from 500 to 250. A single long-running pod accrues ~288 samples over 24h at the 5m cadence, so the 24h `minTimeSpan` rather than the sample count becomes the binding constraint for a lone pod to become eligible.
+
 ## [0.1.8] - 2026-06-30
 
 ### Added

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -587,7 +587,7 @@ _After deploying, confirm the `kubelet-summary` MetricsSource appears and that `
 
 ## Phase 15 — Updated Default Policy, Memory Limits, and Testing Policy
 
-**Status:** `[ ]`
+**Status:** `[x]` — Complete (PR pending)
 **Depends on:** Phase 14, Phase 11
 
 ### What to build
@@ -595,6 +595,10 @@ _After deploying, confirm the `kubelet-summary` MetricsSource appears and that `
 **Default policy formula change (CPU and memory requests):**
 
 Replace the current `p95 * headroom` approach with `avg * 1.25` (= mean / 0.80 target utilization). For a large homogeneous fleet the aggregate memory pressure is predictable; sizing at 80% of mean lets nodes run dense while leaving headroom for normal variation. The 20% drift threshold means the adjuster only fires when actual usage has moved by more than 20% relative to the recommendation, avoiding churn.
+
+**Sampling cadence and readiness (implemented):** the default `kubernetesMetrics`/`kubeletSummary` poll interval moved from 60s to 5m (production fleets don't need second-resolution sampling), and `readiness.minDataPoints` dropped from 500 to 250 so a single long-running pod accrues enough samples (~288 over 24h at the 5m cadence) to cross the gate at the 24h `minTimeSpan` mark rather than being blocked on sample count.
+
+**New aggregations (implemented):** the ephemeral-storage request needs `p90`, which the stats engine did not compute and the `MetricConfig.aggregation` enum did not allow. Added `p75` and `p90` end to end: `store.Stats` + `ComputeStats` (`internal/store/percentiles.go`), the `ContainerUsageStats` CRD fields (`api/v1/workloadprofile_types.go`) populated by the collector, the `aggregation` enum (`api/v1/clusterresourcepolicy_types.go`), and the resolver switch (`internal/stats/aggregator.go`).
 
 **Memory limit (new):**
 
@@ -610,21 +614,18 @@ Add two ephemeral storage entries pointing at the `kubelet-summary` MetricsSourc
 
 The current `clusterresourcepolicy.yaml` template uses a single global `metricsSource` for all metric entries. Update it to prefer `.source` from the metric entry if present, falling back to the global default: `{{ .source | default $.Values.defaultClusterResourcePolicy.metricsSource | quote }}`. This lets CPU/memory entries reference `kubernetes-metrics` and ephemeral-storage entries reference `kubelet-summary` within the same policy object.
 
-**Testing policy (new, disabled by default):**
+**Policy presets (implemented; supersedes the original `testClusterResourcePolicy` design):**
 
-Add a `testClusterResourcePolicy` section in `values.yaml` and a corresponding Helm template. When enabled (e.g. via `--set testClusterResourcePolicy.enabled=true` in `make helm-update-local`), it installs a higher-priority policy tuned for fast feedback during local development:
+Rather than embedding a dev-only `testClusterResourcePolicy` (stanza + always-present template gated by `enabled`) inside the production chart, ship a catalog of policy presets as Helm values overlays under `charts/ballast/presets/`. Anything in the chart is published in every release artifact, so a dev-only resource baked in (even gated) is a footgun; an overlay is inert data that only takes effect when selected with `-f`. The base `values.yaml` default IS the `homogeneous-large-fleet` preset, so a plain `helm install` is production-sane with no flags.
 
-- `priority: 100` (beats the default policy's 0)
-- `readiness.minDataPoints: 5`
-- `readiness.minTimeSpan: "1m"`
-- `readiness.maxCV: "2.0"`
-- `behaviors.resize.interval: "30s"`
-- Same metrics as the default policy (avg * 1.25 for CPU and memory requests; p99 for memory limit)
-- A prominent comment in the values file and the template stating this policy is for development clusters only
+- `charts/ballast/presets/local-testing.yaml` — fast-cycle overlay for kind clusters: `readiness.minDataPoints: 5`, `minTimeSpan: "1m"`, `maxCV: "2.0"`, `behaviors.resize.interval: "30s"`, poll intervals overridden to 15s, and a CPU/memory-only metrics list (drops the ephemeral-storage entries to keep the local loop focused). A prominent header comment states it is development-only.
+- `charts/ballast/presets/README.md` — documents the catalog and how to apply/override presets.
+
+Helm's native `-f` merge gives the preset + override behavior for free (map fields deep-merge, list fields replace), so no template logic and no extra `priority` arbitration is needed — only one `ClusterResourcePolicy` is ever rendered.
 
 **`make helm-update-local` change:**
 
-Pass `--set testClusterResourcePolicy.enabled=true` automatically so local kind clusters always get the fast-cycle policy without manual flags.
+`helm-update-local` sets a target-specific `HELM_LOCAL_EXTRA = -f $(CHART_DIR)/presets/local-testing.yaml` (which GNU Make propagates to its `helm-install-local` prerequisite) so local kind clusters always get the fast-cycle preset without manual flags.
 
 **Testing instructions (add to README or a dedicated TESTING.md):**
 
@@ -637,11 +638,12 @@ Document the full local test loop:
 
 ### Key files
 
-- `charts/ballast/values.yaml` — update `defaultClusterResourcePolicy.metrics` (new formulas + limit entry + ephemeral-storage entries); add `testClusterResourcePolicy` stanza
-- `charts/ballast/templates/clusterresourcepolicy.yaml` — fix per-metric source fallback
-- `charts/ballast/templates/testclusterresourcepolicy.yaml` — new template for the test policy
-- `Makefile` — add `testClusterResourcePolicy.enabled=true` to `helm-update-local`
-- `README.md` or `TESTING.md` — local test loop instructions
+- `internal/store/percentiles.go`, `api/v1/workloadprofile_types.go`, `internal/controller/metricscollector/controller.go`, `api/v1/clusterresourcepolicy_types.go`, `internal/stats/aggregator.go` — add `p75`/`p90` aggregations end to end (plus regenerated CRDs synced to `charts/ballast/crds/`)
+- `charts/ballast/values.yaml` — `defaultClusterResourcePolicy.metrics` (avg*1.25 requests + p99 memory limit + p90/p99 ephemeral-storage entries via `kubelet-summary`); 5m poll intervals; `minDataPoints: 250`
+- `charts/ballast/templates/clusterresourcepolicy.yaml` — per-metric `source` fallback (`.source | default $.Values...metricsSource`)
+- `charts/ballast/presets/local-testing.yaml`, `charts/ballast/presets/README.md` — fast-cycle preset overlay and catalog docs
+- `Makefile` — `helm-update-local` applies the local-testing preset via target-specific `HELM_LOCAL_EXTRA`
+- `TESTING.md` — local test loop instructions (linked from `README.md`)
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,10 @@ check: lint test-coverage-check build ## Full pre-release gate: lint + coverage 
 
 HELM ?= helm
 CHART_DIR ?= charts/ballast
+# HELM_LOCAL_EXTRA is appended to the local install command. helm-update-local sets
+# it (via a target-specific value that propagates to helm-install-local) to apply
+# the local-testing policy preset; override it to layer your own values.
+HELM_LOCAL_EXTRA ?=
 
 helm-build: manifests ## Sync CRDs from config/crd/bases/ and download chart dependencies.
 	cp config/crd/bases/*.yaml $(CHART_DIR)/crds/
@@ -136,9 +140,11 @@ helm-install-local: helm-build ## Install chart into the kind cluster using the 
 	$(HELM) upgrade --install ballast $(CHART_DIR) \
 		--namespace ballast-system --create-namespace \
 		--set image.tag=local \
-		--set image.pullPolicy=Never
+		--set image.pullPolicy=Never \
+		$(HELM_LOCAL_EXTRA)
 
-helm-update-local: docker-kind helm-install-local ## Build, load into kind, and install the chart in one step.
+helm-update-local: HELM_LOCAL_EXTRA = -f $(CHART_DIR)/presets/local-testing.yaml
+helm-update-local: docker-kind helm-install-local ## Build, load into kind, and install with the local-testing policy preset.
 
 ##@ Cluster Deployment
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](http
 | 12 | Polish and release readiness | Complete |
 | 13 | Prometheus and OpenTelemetry metrics | Complete |
 | 14 | `kubeletSummary` plugin (ephemeral storage) | Complete |
+| 15 | Updated default policy, memory/ephemeral limits, policy presets | Complete |
 
 ## Prerequisites
 
@@ -212,7 +213,7 @@ Not yet implemented; tracked as a future Helm chart improvement.
 
 ## Default MetricsSource and ClusterResourcePolicy
 
-A fresh `helm install` ships two objects out of the box so measurements work without any extra setup:
+A fresh `helm install` ships three objects out of the box so measurements work without any extra setup: two `MetricsSource` objects (CPU/memory and ephemeral storage) and one catch-all `ClusterResourcePolicy`.
 
 ### MetricsSource: `kubernetes-metrics`
 
@@ -220,21 +221,38 @@ A fresh `helm install` ships two objects out of the box so measurements work wit
 spec:
   type: kubernetesMetrics
   config:
-    pollInterval: "60s"
+    pollInterval: "300s"
     reservoirSize: 10000
 ```
 
-This wires Ballast to the cluster's [metrics-server](https://github.com/kubernetes-sigs/metrics-server) (which must already be installed — it is not bundled). Samples are collected every 60 seconds and up to 10,000 samples per container per metric are retained in Redis.
+This wires Ballast to the cluster's [metrics-server](https://github.com/kubernetes-sigs/metrics-server) (which must already be installed — it is not bundled) for CPU and memory. Samples are collected every 5 minutes and up to 10,000 samples per container per metric are retained in Redis.
 
-To opt out and manage `MetricsSource` objects yourself:
+### MetricsSource: `kubelet-summary`
+
+```yaml
+spec:
+  type: kubeletSummary
+  config:
+    pollInterval: "300s"
+    reservoirSize: 10000
+```
+
+This reads ephemeral-storage usage from the kubelet Summary API (via the API server proxy). No extra credentials are needed beyond the Ballast ServiceAccount.
+
+To opt out of either source and manage `MetricsSource` objects yourself, set `enabled: false` on the relevant entry:
 
 ```yaml
 # values.yaml
-defaultMetricsSource:
-  enabled: false
+defaultMetricsSources:
+  kubernetesMetrics:
+    enabled: false
+  kubeletSummary:
+    enabled: false
 ```
 
 ### ClusterResourcePolicy: `default`
+
+This is the `homogeneous-large-fleet` preset, the chart's built-in default:
 
 ```yaml
 spec:
@@ -243,15 +261,30 @@ spec:
     - resource: cpu
       field: request
       source: kubernetes-metrics
-      aggregation: p95
-      headroom: "1.2"
+      aggregation: avg
+      headroom: "1.25"
     - resource: memory
       field: request
       source: kubernetes-metrics
-      aggregation: p95
-      headroom: "1.3"
+      aggregation: avg
+      headroom: "1.25"
+    - resource: memory
+      field: limit
+      source: kubernetes-metrics
+      aggregation: p99
+      headroom: "1.0"
+    - resource: ephemeral-storage
+      field: request
+      source: kubelet-summary
+      aggregation: p90
+      headroom: "1.0"
+    - resource: ephemeral-storage
+      field: limit
+      source: kubelet-summary
+      aggregation: p99
+      headroom: "1.0"
   readiness:
-    minDataPoints: 500
+    minDataPoints: 250
     minTimeSpan: "24h"
     maxCV: "1.5"
   behaviors:
@@ -264,12 +297,24 @@ spec:
 
 This catch-all policy applies to every opted-in pod in the cluster. Key design decisions:
 
-- **Requests only, no limits.** Setting memory limits without careful profiling causes OOMKills; CPU limits cause throttling. Add limit entries in a higher-priority policy once you have enough history to trust the recommendations.
-- **p95 with headroom.** CPU requests are set to the 95th-percentile usage × 1.2; memory at p95 × 1.3. Memory gets slightly more headroom because usage spikes are harder to absorb than CPU ones.
-- **500 samples over 24 hours before acting.** This prevents premature resizes on workloads that haven't been observed long enough to produce stable recommendations. A high coefficient of variation (CV > 1.5) also blocks action — it means the workload is too spiky to size reliably.
+- **Requests at `avg * 1.25`.** Sizing CPU and memory requests at 80% of mean (= mean / 0.80 target utilization) keeps nodes dense while leaving headroom for normal variation. For a large homogeneous fleet the aggregate pressure is predictable, so the mean is a reliable basis.
+- **Memory limit at p99, no headroom.** p99 is the highest usage the workload has shown in production; a pod exceeding it is likely leaking and should be OOMKilled. This yields Burstable QoS (limit > request), the right class for most production workloads. **CPU limits are intentionally omitted** — they cause throttling rather than reclaiming waste.
+- **Ephemeral storage from the kubelet Summary API.** The request is sized at p90 (the growth-skewed distribution) and the limit at p99 so the kubelet evicts a runaway pod before the node hits disk pressure.
+- **250 samples over 24 hours before acting.** At the 5-minute poll interval a single long-running pod accrues ~288 samples in 24h, so the 24h window — not the sample count — is the binding constraint. A high coefficient of variation (CV > 1.5) also blocks action — it means the workload is too spiky to size reliably.
 - **20% drift threshold.** A resize only fires when the current resource value deviates from the recommendation by more than 20%, avoiding churn from minor fluctuations.
 - **50% max change per cycle.** Caps how aggressively a single resize can move a value, giving workloads time to stabilize between adjustments.
 - **Priority 0.** This is the lowest possible priority. Any `ClusterResourcePolicy` or `ResourcePolicy` with `priority > 0` wins for matched workloads, so you can override specific namespaces or workload kinds without touching this default.
+
+### Policy presets
+
+The default above is one entry in a catalog of presets — Helm values overlays under [`charts/ballast/presets/`](charts/ballast/presets/README.md) that retune the policy for a particular operating profile. `homogeneous-large-fleet` is built into `values.yaml`; `local-testing` is a fast-cycle overlay for kind clusters. Select one at install time with `-f`:
+
+```bash
+helm install ballast ballast/ballast -n ballast-system --create-namespace \
+  -f charts/ballast/presets/local-testing.yaml
+```
+
+A later `-f` file or `--set` deep-merges on top (map fields merge; list fields like `metrics` are replaced wholesale), so you can layer a preset and override a single field.
 
 To opt out and manage policies yourself:
 
@@ -290,13 +335,15 @@ defaultClusterResourcePolicy:
   metrics:
     - resource: cpu
       field: request
-      aggregation: p95
-      headroom: "1.1"
+      aggregation: avg
+      headroom: "1.2"
     - resource: memory
       field: request
-      aggregation: p95
+      aggregation: avg
       headroom: "1.2"
 ```
+
+> **Note:** `metrics` is a list, so overriding it replaces the entire default list (including the memory-limit and ephemeral-storage entries). Repeat every entry you want to keep.
 
 To add a tighter policy for production namespaces alongside the default, create a higher-priority `ClusterResourcePolicy`:
 
@@ -398,7 +445,7 @@ This runs three steps in sequence:
 
 1. **Build** — `docker build --platform linux/<host-arch>` tagged `:local`. The host architecture is detected automatically via `uname -m`, so the same command works on both ARM and x86 machines.
 2. **Load** — `kind load docker-image` injects the image directly into the kind node; no registry push or GHCR credentials needed.
-3. **Install** — `helm upgrade --install` deploys the chart into `ballast-system` with `image.pullPolicy=Never`, pinning it to the locally loaded image.
+3. **Install** — `helm upgrade --install` deploys the chart into `ballast-system` with `image.pullPolicy=Never`, pinning it to the locally loaded image, and applies the `local-testing` policy preset (`-f charts/ballast/presets/local-testing.yaml`) for fast feedback.
 
 **Individual targets** (when you only need part of the cycle):
 
@@ -414,6 +461,8 @@ kubectl get pods -n ballast-system             # operator pod should be Running
 kubectl logs -n ballast-system -l app.kubernetes.io/name=ballast -f
 kubectl get ballastconfig                      # confirm CRD is installed
 ```
+
+For the full measure → apply → resize walkthrough on a local cluster, see [TESTING.md](TESTING.md).
 
 ## Logging
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,74 @@
+# Local testing
+
+This walks through exercising the full measure → apply → resize loop on a local
+[kind](https://kind.sigs.k8s.io/) cluster, using the `local-testing` policy preset
+so you see results in minutes instead of the 24h the production default requires.
+
+## Prerequisites
+
+- A running kind cluster
+- [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in
+  it (Ballast measures CPU/memory through the Metrics API). On kind you typically
+  need `--set args={--kubelet-insecure-tls}`.
+- [cert-manager](https://cert-manager.io/) installed (the admission webhook needs a
+  CA bundle)
+- Kubernetes 1.35+ for in-place resize; on older versions measure and apply work
+  but resize does not.
+
+## 1. Deploy Ballast with the local-testing preset
+
+```sh
+make helm-update-local KIND_CLUSTER=<name>
+```
+
+This builds the image for your host arch, loads it into the kind cluster, and
+installs the chart with `-f charts/ballast/presets/local-testing.yaml`. That preset
+polls every 15s and lets the default policy act after 5 samples over 1 minute with a
+30s resize interval. (See `charts/ballast/presets/README.md` for the catalog.)
+
+## 2. Install a workload that opts in
+
+```sh
+helm install nginx bitnami/nginx \
+  --namespace nginx --create-namespace \
+  --set commonAnnotations."ballast\.tightlinesoftware\.com/autoresize"=true
+```
+
+The `autoresize` annotation opts the workload into measure + apply + resize. The
+rest of this guide assumes the `nginx` namespace from `--namespace nginx` above.
+
+## 3. Watch the profile become eligible
+
+```sh
+kubectl get -w workloadprofile nginx--nocomponent
+```
+
+`meetsThreshold` flips to `true` after ~5 samples (~1 minute at the 15s poll
+interval).
+
+## 4. Watch admission stamp resources on new pods
+
+```sh
+kubectl get -w pods -n nginx
+```
+
+The next pod created after the profile is ready gets resources applied at admission.
+If the out-of-the-box requests (nginx ships ~50m CPU and generous memory) differ
+from the profile recommendation by more than the 20% drift threshold, the
+ResourceAdjuster resizes the running pod at the 30s interval.
+
+## 5. Confirm the resize
+
+```sh
+kubectl describe pod <name> -n nginx
+```
+
+Check that the `ballast.tightlinesoftware.com/last-resize` annotation is stamped and
+that the container resources match the profile recommendation.
+
+## Cleanup
+
+```sh
+helm uninstall nginx
+helm uninstall ballast -n ballast-system
+```

--- a/api/v1/clusterresourcepolicy_types.go
+++ b/api/v1/clusterresourcepolicy_types.go
@@ -85,8 +85,8 @@ type MetricConfig struct {
 	// +kubebuilder:validation:MinLength=1
 	Source string `json:"source"`
 
-	// Aggregation is the usage percentile to use: p50, p95, p99, max, avg.
-	// +kubebuilder:validation:Enum=p50;p95;p99;max;avg
+	// Aggregation is the usage percentile to use: p50, p75, p90, p95, p99, max, avg.
+	// +kubebuilder:validation:Enum=p50;p75;p90;p95;p99;max;avg
 	Aggregation string `json:"aggregation"`
 
 	// Headroom is the multiplier applied to the aggregated usage value.

--- a/api/v1/workloadprofile_types.go
+++ b/api/v1/workloadprofile_types.go
@@ -100,6 +100,14 @@ type ContainerUsageStats struct {
 	// +optional
 	P50 string `json:"p50,omitempty"`
 
+	// P75 is the 75th percentile of observed usage.
+	// +optional
+	P75 string `json:"p75,omitempty"`
+
+	// P90 is the 90th percentile of observed usage.
+	// +optional
+	P90 string `json:"p90,omitempty"`
+
 	// P95 is the 95th percentile of observed usage.
 	// +optional
 	P95 string `json:"p95,omitempty"`

--- a/charts/ballast/presets/README.md
+++ b/charts/ballast/presets/README.md
@@ -1,0 +1,29 @@
+# Policy presets
+
+Ballast ships a catalog of policy presets: values overlays that retune the default
+`ClusterResourcePolicy` (and the supporting `MetricsSource` poll intervals) for a
+particular operating profile. Pick one at install time with `-f`.
+
+Each preset is a normal Helm values file, so it composes with base `values.yaml`
+and any later `-f`/`--set` you pass: map fields deep-merge, list fields (like
+`defaultClusterResourcePolicy.metrics`) are replaced wholesale, and the
+right-most source wins. That means you can layer a preset and then override a
+single field, e.g.:
+
+```sh
+helm upgrade --install ballast ./charts/ballast \
+  -f charts/ballast/presets/local-testing.yaml \
+  --set defaultClusterResourcePolicy.behaviors.resize.interval=10s
+```
+
+## Available presets
+
+| Preset | File | Use case |
+| --- | --- | --- |
+| `homogeneous-large-fleet` | _(built-in default in `values.yaml`)_ | Production fleets of many similar pods. Sizes requests at `avg * 1.25`, memory limit at p99, and ephemeral storage from the kubelet Summary API. Polls every 5m and requires 250 samples over 24h before acting. |
+| `local-testing` | `local-testing.yaml` | Local kind clusters. Polls every 15s and acts after 5 samples over 1m with a 30s resize interval, so you can watch a workload become eligible and get resized within minutes. **Never use in production.** |
+
+The `homogeneous-large-fleet` preset is the chart's built-in default, so a plain
+`helm install` with no `-f` already gives you a production-sane policy. To add a
+new preset, drop a values overlay in this directory and document it in the table
+above.

--- a/charts/ballast/presets/local-testing.yaml
+++ b/charts/ballast/presets/local-testing.yaml
@@ -1,0 +1,48 @@
+# local-testing preset
+#
+# A values overlay tuned for fast feedback on a local kind cluster. Apply it on top
+# of the base chart values with `-f`:
+#
+#   helm upgrade --install ballast ./charts/ballast \
+#     -f charts/ballast/presets/local-testing.yaml
+#
+# `make helm-update-local` applies this automatically.
+#
+# DO NOT use this on a production cluster. The tiny readiness thresholds and the
+# 30s resize interval will resize workloads off a handful of noisy samples.
+#
+# This overlay only restates the fields that differ from the base values. Map
+# fields deep-merge over the base; the `metrics` list is replaced wholesale, so the
+# full list is repeated here. It intentionally drops the ephemeral-storage entries
+# the production default carries so the local loop stays focused on watching CPU and
+# memory resizes; ephemeral storage is exercised by the default preset.
+
+defaultMetricsSources:
+  # Poll every 15s so ~5 samples accrue in ~1 minute, clearing the readiness gate
+  # below almost immediately.
+  kubernetesMetrics:
+    pollInterval: "15s"
+  kubeletSummary:
+    pollInterval: "15s"
+
+defaultClusterResourcePolicy:
+  metrics:
+    - resource: cpu
+      field: request
+      aggregation: avg
+      headroom: "1.25"
+    - resource: memory
+      field: request
+      aggregation: avg
+      headroom: "1.25"
+    - resource: memory
+      field: limit
+      aggregation: p99
+      headroom: "1.0"
+  readiness:
+    minDataPoints: 5
+    minTimeSpan: "1m"
+    maxCV: "2.0"
+  behaviors:
+    resize:
+      interval: "30s"

--- a/charts/ballast/templates/clusterresourcepolicy.yaml
+++ b/charts/ballast/templates/clusterresourcepolicy.yaml
@@ -11,7 +11,7 @@ spec:
   {{- range .Values.defaultClusterResourcePolicy.metrics }}
   - resource: {{ .resource | quote }}
     field: {{ .field | quote }}
-    source: {{ $.Values.defaultClusterResourcePolicy.metricsSource | quote }}
+    source: {{ .source | default $.Values.defaultClusterResourcePolicy.metricsSource | quote }}
     aggregation: {{ .aggregation | quote }}
     headroom: {{ .headroom | quote }}
   {{- end }}

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -86,8 +86,12 @@ defaultMetricsSources:
   kubernetesMetrics:
     enabled: true
     name: kubernetes-metrics
-    # pollInterval is the minimum time between collection cycles.
-    pollInterval: "60s"
+    # pollInterval is the minimum time between collection cycles. At 5m a single
+    # pod accrues ~288 samples over 24h, which clears the default policy's
+    # minDataPoints (250) so a lone long-running pod becomes eligible at the 24h
+    # minTimeSpan mark. Local testing overrides this to a few seconds; see
+    # charts/ballast/presets/local-testing.yaml.
+    pollInterval: "300s"
     # reservoirSize is the hard cap on stored samples per container per metric.
     reservoirSize: 10000
   # kubeletSummary uses the kubelet Summary API (via the API server proxy) for
@@ -96,7 +100,7 @@ defaultMetricsSources:
   kubeletSummary:
     enabled: true
     name: kubelet-summary
-    pollInterval: "60s"
+    pollInterval: "300s"
     reservoirSize: 10000
 
 telemetry:
@@ -130,8 +134,16 @@ telemetry:
     interval: "30s"
 
 # defaultClusterResourcePolicy installs a catch-all policy that applies to all
-# opted-in pods. It measures CPU and memory requests at p95 with conservative
-# headroom and requires 500 samples over 24 hours before acting.
+# opted-in pods. The values below are the "homogeneous-large-fleet" preset: it
+# sizes CPU and memory requests at avg * 1.25 (= mean / 0.80 target utilization),
+# sets a memory limit at p99, and sizes ephemeral storage requests/limits from the
+# kubelet Summary API. It requires 500 samples over 24 hours before acting.
+#
+# This is the built-in default preset. Other presets ship as values overlays under
+# charts/ballast/presets/ (see presets/README.md) and are selected at install time
+# with `-f`, e.g. `helm install ... -f charts/ballast/presets/local-testing.yaml`.
+# A later `-f` file or `--set` deep-merges on top of these values (map fields merge;
+# list fields like `metrics` are replaced wholesale).
 #
 # Set enabled: false if you want to manage ClusterResourcePolicy objects yourself.
 # To scope the default policy to specific namespaces or workload kinds, set
@@ -143,25 +155,51 @@ defaultClusterResourcePolicy:
   enabled: true
   name: default
   priority: 0
-  # metricsSource is the MetricsSource name referenced by each metric entry below.
-  # Change this if you disable defaultMetricsSource and create your own.
+  # metricsSource is the default MetricsSource name; a metric entry without its
+  # own `source` falls back to this. Change it if you disable defaultMetricsSources
+  # and create your own. Ephemeral-storage entries override it with kubelet-summary.
   metricsSource: kubernetes-metrics
   # metrics defines what to measure and which resource fields to set.
-  # Limits are intentionally omitted from the defaults: setting memory limits
-  # without careful profiling can cause OOMKills, and CPU limits cause throttling.
-  # Add limit entries here (or in a higher-priority policy) when you are ready.
+  #
+  # Requests are sized at avg * 1.25: for a large homogeneous fleet the aggregate
+  # pressure is predictable, so sizing at 80% of mean keeps nodes dense while
+  # leaving headroom for normal variation. The memory limit is set at p99 (the
+  # highest usage seen in production) with no headroom — a pod that exceeds p99 is
+  # likely leaking and should be OOMKilled. This yields Burstable QoS (limit >
+  # request), the right class for most production workloads. CPU limits are
+  # intentionally omitted: they cause throttling rather than reclaiming waste.
   metrics:
     - resource: cpu
       field: request
-      aggregation: p95
-      headroom: "1.2"
+      aggregation: avg
+      headroom: "1.25"
     - resource: memory
       field: request
-      aggregation: p95
-      headroom: "1.3"
+      aggregation: avg
+      headroom: "1.25"
+    - resource: memory
+      field: limit
+      aggregation: p99
+      headroom: "1.0"
+    # Ephemeral-storage entries read from the kubelet Summary API. The request is
+    # sized at p90 (the growth-skewed distribution) and the limit at p99 so the
+    # kubelet evicts a runaway pod before the node hits disk pressure.
+    - resource: ephemeral-storage
+      field: request
+      source: kubelet-summary
+      aggregation: p90
+      headroom: "1.0"
+    - resource: ephemeral-storage
+      field: limit
+      source: kubelet-summary
+      aggregation: p99
+      headroom: "1.0"
   readiness:
     # minDataPoints is the minimum number of samples before Ballast will act.
-    minDataPoints: 500
+    # Sized against the 5m poll interval above: a single pod running 24h accrues
+    # ~288 samples, so 250 keeps the 24h minTimeSpan (not the sample count) as the
+    # binding constraint while leaving margin for occasional missed polls.
+    minDataPoints: 250
     # minTimeSpan is the minimum history window required.
     minTimeSpan: "24h"
     # maxCV is the maximum coefficient of variation (stddev/mean) allowed.

--- a/config/crd/bases/ballast.tightlinesoftware.com_clusterresourcepolicies.yaml
+++ b/config/crd/bases/ballast.tightlinesoftware.com_clusterresourcepolicies.yaml
@@ -111,9 +111,11 @@ spec:
                   properties:
                     aggregation:
                       description: 'Aggregation is the usage percentile to use: p50,
-                        p95, p99, max, avg.'
+                        p75, p90, p95, p99, max, avg.'
                       enum:
                       - p50
+                      - p75
+                      - p90
                       - p95
                       - p99
                       - max

--- a/config/crd/bases/ballast.tightlinesoftware.com_resourcepolicies.yaml
+++ b/config/crd/bases/ballast.tightlinesoftware.com_resourcepolicies.yaml
@@ -110,9 +110,11 @@ spec:
                   properties:
                     aggregation:
                       description: 'Aggregation is the usage percentile to use: p50,
-                        p95, p99, max, avg.'
+                        p75, p90, p95, p99, max, avg.'
                       enum:
                       - p50
+                      - p75
+                      - p90
                       - p95
                       - p99
                       - max

--- a/config/crd/bases/ballast.tightlinesoftware.com_workloadprofiles.yaml
+++ b/config/crd/bases/ballast.tightlinesoftware.com_workloadprofiles.yaml
@@ -165,6 +165,12 @@ spec:
                           p50:
                             description: P50 is the 50th percentile of observed usage.
                             type: string
+                          p75:
+                            description: P75 is the 75th percentile of observed usage.
+                            type: string
+                          p90:
+                            description: P90 is the 90th percentile of observed usage.
+                            type: string
                           p95:
                             description: P95 is the 95th percentile of observed usage.
                             type: string

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -489,6 +489,8 @@ func buildUsageStats(resourceName, sourceName string, s store.Stats, firstMs, la
 		Samples:     int64(s.Count),
 		TimeSpan:    formatDuration(lastMs - firstMs),
 		P50:         formatResourceValue(resourceName, s.P50),
+		P75:         formatResourceValue(resourceName, s.P75),
+		P90:         formatResourceValue(resourceName, s.P90),
 		P95:         formatResourceValue(resourceName, s.P95),
 		P99:         formatResourceValue(resourceName, s.P99),
 		Mean:        formatResourceValue(resourceName, s.Mean),

--- a/internal/controller/workloadwatcher/controller_test.go
+++ b/internal/controller/workloadwatcher/controller_test.go
@@ -163,6 +163,15 @@ func TestPodReconciler_NewPod(t *testing.T) {
 	}
 }
 
+func TestPodReconciler_NotFound(t *testing.T) {
+	// A reconcile request for a pod that no longer exists (already deleted) must
+	// be a no-op: Get returns NotFound and Reconcile returns nil without error.
+	fc := newFakeClient(defaultBallastConfig())
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+
+	reconcilePod(t, c, "default", "ghost-pod")
+}
+
 func TestPodReconciler_AlreadyProcessed(t *testing.T) {
 	ctx := context.Background()
 

--- a/internal/stats/aggregator.go
+++ b/internal/stats/aggregator.go
@@ -48,6 +48,10 @@ func ComputeRecommendation(s store.Stats, metric ballastv1.MetricConfig) (resour
 	switch metric.Aggregation {
 	case "p50":
 		base = s.P50
+	case "p75":
+		base = s.P75
+	case "p90":
+		base = s.P90
 	case "p95":
 		base = s.P95
 	case "p99":

--- a/internal/stats/aggregator_test.go
+++ b/internal/stats/aggregator_test.go
@@ -107,6 +107,8 @@ func TestEvaluateReadiness(t *testing.T) {
 func TestComputeRecommendation(t *testing.T) {
 	s := store.Stats{
 		P50:  100,
+		P75:  175,
+		P90:  190,
 		P95:  200,
 		P99:  300,
 		Max:  400,
@@ -138,6 +140,16 @@ func TestComputeRecommendation(t *testing.T) {
 			name:   "p50 aggregation",
 			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p50", Headroom: "1.0"},
 			want:   resource.MustParse("100m"),
+		},
+		{
+			name:   "p75 aggregation",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p75", Headroom: "1.0"},
+			want:   resource.MustParse("175m"),
+		},
+		{
+			name:   "p90 aggregation",
+			metric: ballastv1.MetricConfig{Resource: "cpu", Aggregation: "p90", Headroom: "1.0"},
+			want:   resource.MustParse("190m"),
 		},
 		{
 			name:   "max aggregation",

--- a/internal/store/percentiles.go
+++ b/internal/store/percentiles.go
@@ -5,6 +5,8 @@ import "math"
 // Stats holds statistical measures for a set of samples.
 type Stats struct {
 	P50    float64
+	P75    float64
+	P90    float64
 	P95    float64
 	P99    float64
 	Max    float64
@@ -50,6 +52,8 @@ func ComputeStats(values []int64) Stats {
 
 	return Stats{
 		P50:    percentile(50),
+		P75:    percentile(75),
+		P90:    percentile(90),
 		P95:    percentile(95),
 		P99:    percentile(99),
 		Max:    float64(values[n-1]),

--- a/internal/store/percentiles_test.go
+++ b/internal/store/percentiles_test.go
@@ -19,7 +19,7 @@ func TestComputeStats_Single(t *testing.T) {
 	if s.Count != 1 {
 		t.Errorf("Count = %d, want 1", s.Count)
 	}
-	if s.P50 != 100 || s.P95 != 100 || s.P99 != 100 || s.Max != 100 || s.Mean != 100 {
+	if s.P50 != 100 || s.P75 != 100 || s.P90 != 100 || s.P95 != 100 || s.P99 != 100 || s.Max != 100 || s.Mean != 100 {
 		t.Errorf("unexpected stats for single value: %+v", s)
 	}
 	if s.StdDev != 0 || s.CV != 0 {
@@ -38,6 +38,14 @@ func TestComputeStats_Percentiles(t *testing.T) {
 	// p50: ceil(50/100 * 20) = rank 10 → value 10
 	if s.P50 != 10 {
 		t.Errorf("P50 = %v, want 10", s.P50)
+	}
+	// p75: ceil(75/100 * 20) = rank 15 → value 15
+	if s.P75 != 15 {
+		t.Errorf("P75 = %v, want 15", s.P75)
+	}
+	// p90: ceil(90/100 * 20) = rank 18 → value 18
+	if s.P90 != 18 {
+		t.Errorf("P90 = %v, want 18", s.P90)
 	}
 	// p95: ceil(95/100 * 20) = rank 19 → value 19
 	if s.P95 != 19 {


### PR DESCRIPTION
## Summary

Implements Phase 15. Two design decisions during review shaped the final shape (see notes below).

### New `p75`/`p90` aggregations (prerequisite)
Phase 15's ephemeral-storage request needs `p90`, which the stats engine didn't compute and the `aggregation` enum didn't allow. Added `p75` and `p90` end to end:
- `internal/store/percentiles.go` — `Stats` fields + `ComputeStats`
- `api/v1/workloadprofile_types.go` — `ContainerUsageStats` fields, populated in `metricscollector/controller.go`
- `api/v1/clusterresourcepolicy_types.go` — `aggregation` enum
- `internal/stats/aggregator.go` — resolver switch
- Tests extended; CRDs regenerated.

### Production default policy (`homogeneous-large-fleet`)
In `values.yaml`: requests at `avg * 1.25`, memory limit at `p99`, ephemeral-storage request/limit at `p90`/`p99` via `kubelet-summary`. Poll intervals moved 60s → 5m and `minDataPoints` 500 → 250 so a single pod running 24h (~288 samples) becomes eligible at the `minTimeSpan` mark rather than on sample count.

### Per-metric source fallback
`clusterresourcepolicy.yaml` uses `.source | default $.Values...metricsSource`, so CPU/memory entries use `kubernetes-metrics` and ephemeral entries use `kubelet-summary` in one policy.

### Policy presets instead of an in-chart test policy
The dev policy is **not** baked into the production chart. Instead, a preset catalog: `charts/ballast/presets/local-testing.yaml` + `presets/README.md`, selected via Helm's native `-f` merge. `make helm-update-local` applies it through a target-specific `HELM_LOCAL_EXTRA`. `TESTING.md` documents the full local loop; README policy/MetricsSource sections and the status table are current.

## Design notes (deviations from the original plan)
- **`p75` added alongside `p90`** at request.
- **Presets, not a `testClusterResourcePolicy` stanza/template.** Anything in the chart ships in every release artifact, so a dev-only resource baked in (even gated by `enabled`) is a footgun. A values overlay is inert data that only takes effect when selected with `-f`, and gives a documented, growable catalog. The base `values.yaml` default IS the `homogeneous-large-fleet` preset, so a plain `helm install` is production-sane with no flags.

## Verification
- `make lint` — 0 issues
- `make helm-lint` — 0 chart(s) failed
- `make test-coverage-check` — passed, 72.6% (stats 100%, store 84.4%, metricscollector 92.3%)
- `helm template` renders both the default and the `local-testing` overlay correctly; verified the Makefile flag propagates to `helm-install-local`.