### PR TITLE
Clear SonarCloud new-code issues + ephemeral-storage docs

### DIFF
--- a/.devcontainer/post-install.sh
+++ b/.devcontainer/post-install.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 SEPARATOR="------------------------------------"
 SECTION="===================================="
 
+# Shared curl flags: enforce HTTPS with TLS 1.2+ on every download.
+CURL_TLS=(--proto '=https' --tlsv1.2)
+
 echo "${SECTION}"
 echo "Kubebuilder DevContainer Setup"
 echo "${SECTION}"
@@ -53,7 +56,7 @@ echo "${SEPARATOR}"
 # Install kind
 if ! command -v kind &> /dev/null; then
   echo "Installing kind..."
-  curl --proto '=https' --tlsv1.2 -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
+  curl "${CURL_TLS[@]}" -Lo /usr/local/bin/kind "https://kind.sigs.k8s.io/dl/latest/kind-linux-${ARCH}"
   chmod +x /usr/local/bin/kind
   echo "kind installed successfully"
 fi
@@ -70,7 +73,7 @@ fi
 # Install kubebuilder
 if ! command -v kubebuilder &> /dev/null; then
   echo "Installing kubebuilder..."
-  curl --proto '=https' --tlsv1.2 -Lo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
+  curl "${CURL_TLS[@]}" -Lo /usr/local/bin/kubebuilder "https://go.kubebuilder.io/dl/latest/linux/${ARCH}"
   chmod +x /usr/local/bin/kubebuilder
   echo "kubebuilder installed successfully"
 fi
@@ -87,8 +90,8 @@ fi
 # Install kubectl
 if ! command -v kubectl &> /dev/null; then
   echo "Installing kubectl..."
-  KUBECTL_VERSION=$(curl --proto '=https' --tlsv1.2 -Ls https://dl.k8s.io/release/stable.txt)
-  curl --proto '=https' --tlsv1.2 -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
+  KUBECTL_VERSION=$(curl "${CURL_TLS[@]}" -Ls https://dl.k8s.io/release/stable.txt)
+  curl "${CURL_TLS[@]}" -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${ARCH}/kubectl"
   chmod +x /usr/local/bin/kubectl
   echo "kubectl installed successfully"
 fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Add Helm repositories
         run: |
@@ -98,7 +98,7 @@ jobs:
         run: helm dependency update charts/ballast
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.6.0
+        uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:
           skip_existing: true
         env:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Ballast is a Kubernetes operator that automatically right-sizes workload resourc
 
 ## How it works
 
-Workloads opt in with annotations on their pod templates. Ballast observes real CPU and memory utilization, accumulates a rolling history keyed to a *workload identity tuple* (a set of pod labels you configure), and uses that history to:
+Workloads opt in with annotations on their pod templates. Ballast observes real CPU, memory, and ephemeral-storage utilization, accumulates a rolling history keyed to a *workload identity tuple* (a set of pod labels you configure), and uses that history to right-size all three resources:
 
 1. **Measure** — collect per-container usage samples into a time-series store (Redis/Valkey).
 2. **Apply** — patch resource requests and limits at admission time when a pod is created.
@@ -41,7 +41,7 @@ Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](http
 ## Prerequisites
 
 - Kubernetes 1.35+ (required for in-place pod resize; earlier versions support measure and apply but not resize)
-- [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in the cluster
+- [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in the cluster (source for CPU and memory; ephemeral-storage usage comes from the kubelet Summary API and needs no extra component)
 - TLS certificate for the admission webhook (see [Webhook TLS](#webhook-tls) below)
 - A Redis-compatible store (Ballast ships with a bundled Valkey via Helm; an existing Redis or Valkey instance works too)
 
@@ -147,7 +147,7 @@ kubectl get workloadprofiles
 kubectl describe workloadprofile billing--api--prod
 ```
 
-The profile status shows accumulated usage statistics and recommendations once the readiness threshold is met (default: 500 samples collected over 24 hours):
+The profile status shows accumulated usage statistics and recommendations once the readiness threshold is met (default: 250 samples collected over 24 hours). CPU, memory, and ephemeral storage are all tracked and sized:
 
 ```yaml
 status:
@@ -155,14 +155,31 @@ status:
     - name: app
       usageStats:
         - resource: cpu
-          samples: 1440
+          samples: 288
+          mean: "230m"
           p95: "240m"
           p99: "310m"
           cv: "0.46"
+        - resource: memory
+          samples: 288
+          mean: "180Mi"
+          p95: "210Mi"
+          p99: "240Mi"
+          cv: "0.21"
+        - resource: ephemeral-storage
+          samples: 288
+          p90: "1200Mi"
+          p99: "1800Mi"
+          cv: "0.33"
       recommendations:
         cpu:
-          request: "288m"   # p95 * 1.2 headroom
-          limit: "388m"     # p99 * 1.25 headroom
+          request: "288m"     # avg * 1.25 headroom
+        memory:
+          request: "225Mi"    # avg * 1.25 headroom
+          limit: "240Mi"      # p99
+        ephemeral-storage:
+          request: "1200Mi"   # p90
+          limit: "1800Mi"     # p99
   meetsThreshold: true
   activeWorkloads: 3
 ```

--- a/TESTING.md
+++ b/TESTING.md
@@ -8,8 +8,9 @@ so you see results in minutes instead of the 24h the production default requires
 
 - A running kind cluster
 - [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in
-  it (Ballast measures CPU/memory through the Metrics API). On kind you typically
-  need `--set args={--kubelet-insecure-tls}`.
+  it (Ballast measures CPU and memory through the Metrics API; ephemeral storage
+  comes from the kubelet Summary API, which needs no extra component). On kind you
+  typically need `--set args={--kubelet-insecure-tls}`.
 - [cert-manager](https://cert-manager.io/) installed (the admission webhook needs a
   CA bundle)
 - Kubernetes 1.35+ for in-place resize; on older versions measure and apply work

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -22,9 +22,11 @@ resources:
   limits:
     cpu: 500m
     memory: 128Mi
+    ephemeral-storage: 256Mi
   requests:
     cpu: 10m
     memory: 64Mi
+    ephemeral-storage: 64Mi
 
 logging:
   level: info

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"time"
 
@@ -197,20 +198,6 @@ func run() int {
 
 	// +kubebuilder:scaffold:builder
 
-	metricsClient, err := metricsclientset.NewForConfig(mgr.GetConfig())
-	if err != nil {
-		setupLog.Error(err, "Failed to create metrics clientset")
-		return 1
-	}
-	plugin.Register(k8splugin.New(metricsClient.MetricsV1beta1().PodMetricses(""), k8splugin.DefaultOptions()))
-
-	kubeletPlugin, err := kubeletplugin.New(mgr.GetConfig(), kubeletplugin.DefaultOptions())
-	if err != nil {
-		setupLog.Error(err, "Failed to create kubelet summary plugin")
-		return 1
-	}
-	plugin.Register(kubeletPlugin)
-
 	storeClient, err := store.NewClient(redisURL)
 	if err != nil {
 		setupLog.Error(err, "Failed to create Redis client")
@@ -240,35 +227,9 @@ func run() int {
 		return 1
 	}
 
-	ks := killswitch.New(mgr.GetClient(), operatorNamespace, rec)
-	if err := ks.SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to set up kill switch")
-		return 1
-	}
-
-	if err := workloadwatcher.New(mgr.GetClient(), ks, storeClient, rec).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "Failed to set up workloadwatcher controller")
-		return 1
-	}
-
-	if err := metricscollector.Setup(mgr, ks, storeClient, dryRunMeasure, rec); err != nil {
-		setupLog.Error(err, "Failed to set up metricscollector controller")
-		return 1
-	}
-
-	ballastwebhook.NewPodMutator(mgr.GetClient(), ks, dryRunApply, rec).SetupWithManager(mgr)
-
-	if err := resourceadjuster.Setup(mgr, ks, dryRunResize, rec); err != nil {
-		setupLog.Error(err, "Failed to set up resourceadjuster controller")
-		return 1
-	}
-
-	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "Failed to set up health check")
-		return 1
-	}
-	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "Failed to set up ready check")
+	if err := registerComponents(mgr, storeClient, rec, operatorNamespace,
+		dryRunMeasure, dryRunApply, dryRunResize); err != nil {
+		setupLog.Error(err, "Failed to register components")
 		return 1
 	}
 
@@ -278,4 +239,54 @@ func run() int {
 		return 1
 	}
 	return 0
+}
+
+// registerComponents wires the metrics plugins, kill switch, controllers, webhook,
+// and health checks into the manager. It returns the first setup error, wrapped
+// with context, so run() can report it from a single call site.
+func registerComponents(
+	mgr ctrl.Manager,
+	storeClient store.Client,
+	rec *appmetrics.Recorder,
+	operatorNamespace string,
+	dryRunMeasure, dryRunApply, dryRunResize bool,
+) error {
+	metricsClient, err := metricsclientset.NewForConfig(mgr.GetConfig())
+	if err != nil {
+		return fmt.Errorf("create metrics clientset: %w", err)
+	}
+	plugin.Register(k8splugin.New(metricsClient.MetricsV1beta1().PodMetricses(""), k8splugin.DefaultOptions()))
+
+	kubeletPlugin, err := kubeletplugin.New(mgr.GetConfig(), kubeletplugin.DefaultOptions())
+	if err != nil {
+		return fmt.Errorf("create kubelet summary plugin: %w", err)
+	}
+	plugin.Register(kubeletPlugin)
+
+	ks := killswitch.New(mgr.GetClient(), operatorNamespace, rec)
+	if err := ks.SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("set up kill switch: %w", err)
+	}
+
+	if err := workloadwatcher.New(mgr.GetClient(), ks, storeClient, rec).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("set up workloadwatcher controller: %w", err)
+	}
+
+	if err := metricscollector.Setup(mgr, ks, storeClient, dryRunMeasure, rec); err != nil {
+		return fmt.Errorf("set up metricscollector controller: %w", err)
+	}
+
+	ballastwebhook.NewPodMutator(mgr.GetClient(), ks, dryRunApply, rec).SetupWithManager(mgr)
+
+	if err := resourceadjuster.Setup(mgr, ks, dryRunResize, rec); err != nil {
+		return fmt.Errorf("set up resourceadjuster controller: %w", err)
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		return fmt.Errorf("set up health check: %w", err)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		return fmt.Errorf("set up ready check: %w", err)
+	}
+	return nil
 }

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -231,52 +231,67 @@ func computeAdjustments(
 		if !ok || len(recs) == 0 {
 			continue
 		}
-
-		adj := ContainerAdjustment{
-			Name:     c.Name,
-			Requests: c.Resources.Requests.DeepCopy(),
-			Limits:   c.Resources.Limits.DeepCopy(),
-		}
-		if adj.Requests == nil {
-			adj.Requests = make(corev1.ResourceList)
-		}
-		if adj.Limits == nil {
-			adj.Limits = make(corev1.ResourceList)
-		}
-
-		drifted := false
-		for res, rec := range recs {
-			resName := corev1.ResourceName(res)
-
-			if rec.Request != "" {
-				threshold := ResolveFieldThreshold(behaviors, res, "request")
-				if recommended, err := resource.ParseQuantity(rec.Request); err == nil {
-					current := currentValue(c.Resources.Requests, resName)
-					if ExceedsDrift(current, recommended, threshold) {
-						drifted = true
-						adj.Requests[resName] = CapChange(current, recommended, maxChange)
-					}
-				}
-			}
-
-			if rec.Limit != "" {
-				threshold := ResolveFieldThreshold(behaviors, res, "limit")
-				if recommended, err := resource.ParseQuantity(rec.Limit); err == nil {
-					current := currentValue(c.Resources.Limits, resName)
-					if ExceedsDrift(current, recommended, threshold) {
-						drifted = true
-						adj.Limits[resName] = CapChange(current, recommended, maxChange)
-					}
-				}
-			}
-		}
-
-		if drifted {
+		if adj, drifted := computeContainerAdjustment(c, recs, behaviors, maxChange); drifted {
 			result = append(result, adj)
 		}
 	}
 
 	return result
+}
+
+// computeContainerAdjustment evaluates every recommended field for one container
+// and returns the capped adjustment plus whether any field drifted beyond threshold.
+func computeContainerAdjustment(
+	c corev1.Container,
+	recs map[string]ballastv1.ResourceRecommendation,
+	behaviors ballastv1.BehaviorConfig,
+	maxChange float64,
+) (ContainerAdjustment, bool) {
+	adj := ContainerAdjustment{
+		Name:     c.Name,
+		Requests: c.Resources.Requests.DeepCopy(),
+		Limits:   c.Resources.Limits.DeepCopy(),
+	}
+	if adj.Requests == nil {
+		adj.Requests = make(corev1.ResourceList)
+	}
+	if adj.Limits == nil {
+		adj.Limits = make(corev1.ResourceList)
+	}
+
+	drifted := false
+	for res, rec := range recs {
+		resName := corev1.ResourceName(res)
+		if evaluateField(adj.Requests, resName, rec.Request,
+			ResolveFieldThreshold(behaviors, res, "request"), maxChange,
+			currentValue(c.Resources.Requests, resName)) {
+			drifted = true
+		}
+		if evaluateField(adj.Limits, resName, rec.Limit,
+			ResolveFieldThreshold(behaviors, res, "limit"), maxChange,
+			currentValue(c.Resources.Limits, resName)) {
+			drifted = true
+		}
+	}
+	return adj, drifted
+}
+
+// evaluateField records the capped target for one field in dst when the recommended
+// value parses and drifts beyond threshold; it returns whether the field drifted.
+// An empty recValue parses to an error and is treated as "no recommendation".
+func evaluateField(
+	dst corev1.ResourceList,
+	resName corev1.ResourceName,
+	recValue string,
+	threshold, maxChange float64,
+	current resource.Quantity,
+) bool {
+	recommended, err := resource.ParseQuantity(recValue)
+	if err != nil || !ExceedsDrift(current, recommended, threshold) {
+		return false
+	}
+	dst[resName] = CapChange(current, recommended, maxChange)
+	return true
 }
 
 // resolveFieldThreshold looks up a per-field threshold using the coalesce order:

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -41,70 +41,40 @@ func NewRecorder(provider metric.MeterProvider) (*Recorder, error) {
 	r.ksReason.Store("")
 
 	var err error
-
-	if r.samplesCollected, err = m.Int64Counter("ballast.samples.collected",
-		metric.WithDescription("Metric samples collected and written to the store"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
+	// counter registers an Int64Counter, latching the first error so callers can
+	// register every instrument in a flat list and check err once at the end.
+	counter := func(name, desc string) metric.Int64Counter {
+		if err != nil { // coverage:ignore - short-circuits once a prior registration has failed
+			return nil
+		}
+		var c metric.Int64Counter
+		c, err = m.Int64Counter(name, metric.WithDescription(desc))
+		return c
 	}
 
-	if r.fetchErrors, err = m.Int64Counter("ballast.fetch.errors",
-		metric.WithDescription("Errors returned by FetchStats for a metrics source"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.profileThresholdMet, err = m.Int64Counter("ballast.profiles.threshold_met",
-		metric.WithDescription("WorkloadProfiles that transitioned to meets-threshold"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.podsProcessed, err = m.Int64Counter("ballast.pods.processed",
-		metric.WithDescription("Pods processed by the workload watcher (created or deleted)"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.workloadProfilesCreated, err = m.Int64Counter("ballast.workload_profiles.created",
-		metric.WithDescription("WorkloadProfile objects created"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.workloadProfilesPurged, err = m.Int64Counter("ballast.workload_profiles.purged",
-		metric.WithDescription("WorkloadProfile objects purged after orphan TTL expired"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.resizeApplied, err = m.Int64Counter("ballast.resize.applied",
-		metric.WithDescription("In-place resize operations applied successfully"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.resizeFailed, err = m.Int64Counter("ballast.resize.failed",
-		metric.WithDescription("In-place resize operations that failed"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.resizeSkipped, err = m.Int64Counter("ballast.resize.skipped",
-		metric.WithDescription("Resize evaluations skipped before issuing a patch"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.webhookMutations, err = m.Int64Counter("ballast.webhook.mutations",
-		metric.WithDescription("Pod admission webhook invocations and their outcomes"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
-		return nil, err
-	}
-
-	if r.killSwitchTransitions, err = m.Int64Counter("ballast.kill_switch.transitions",
-		metric.WithDescription("Kill switch state transitions (activated or deactivated)"),
-	); err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
+	r.samplesCollected = counter("ballast.samples.collected",
+		"Metric samples collected and written to the store")
+	r.fetchErrors = counter("ballast.fetch.errors",
+		"Errors returned by FetchStats for a metrics source")
+	r.profileThresholdMet = counter("ballast.profiles.threshold_met",
+		"WorkloadProfiles that transitioned to meets-threshold")
+	r.podsProcessed = counter("ballast.pods.processed",
+		"Pods processed by the workload watcher (created or deleted)")
+	r.workloadProfilesCreated = counter("ballast.workload_profiles.created",
+		"WorkloadProfile objects created")
+	r.workloadProfilesPurged = counter("ballast.workload_profiles.purged",
+		"WorkloadProfile objects purged after orphan TTL expired")
+	r.resizeApplied = counter("ballast.resize.applied",
+		"In-place resize operations applied successfully")
+	r.resizeFailed = counter("ballast.resize.failed",
+		"In-place resize operations that failed")
+	r.resizeSkipped = counter("ballast.resize.skipped",
+		"Resize evaluations skipped before issuing a patch")
+	r.webhookMutations = counter("ballast.webhook.mutations",
+		"Pod admission webhook invocations and their outcomes")
+	r.killSwitchTransitions = counter("ballast.kill_switch.transitions",
+		"Kill switch state transitions (activated or deactivated)")
+	if err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
 		return nil, err
 	}
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -259,16 +259,6 @@ var _ = Describe("Manager", Ordered, func() {
 		})
 
 		// +kubebuilder:scaffold:e2e-webhooks-checks
-
-		// TODO: Customize the e2e test suite with scenarios specific to your project.
-		// Consider applying sample/CR(s) and check their status and/or verifying
-		// the reconciliation by using the metrics, i.e.:
-		// metricsOutput, err := getMetricsOutput()
-		// Expect(err).NotTo(HaveOccurred(), "Failed to retrieve logs from curl pod")
-		// Expect(metricsOutput).To(ContainSubstring(
-		//    fmt.Sprintf(`controller_runtime_reconcile_total{controller="%s",result="success"} 1`,
-		//    strings.ToLower(<Kind>),
-		// ))
 	})
 })
 


### PR DESCRIPTION
Clears all 8 open issues in the SonarCloud new-code period, plus a docs pass making ephemeral storage first-class.

## SonarCloud fixes

| Rule | Where | Fix |
|---|---|---|
| `go:S3776` (complexity 16) | `internal/metrics/recorder.go` | Collapse 11 repetitive `Int64Counter` registrations into a latching helper closure |
| `go:S3776` (complexity 18) | `cmd/ballastd/main.go` | Extract controller/plugin/health wiring into `registerComponents`, returning wrapped errors |
| `go:S3776` (complexity 36) | `internal/controller/resourceadjuster/controller.go` | Split `computeAdjustments` into per-container and per-field helpers |
| `githubactions:S7637` ×2 | `.github/workflows/release.yml` | Pin `azure/setup-helm` and `helm/chart-releaser-action` to commit SHAs (with `# vX` comments) |
| `kubernetes:S6897` | `charts/ballast/templates/deployment.yaml` | Add ephemeral-storage request/limit to the controller container (via `values.yaml`) |
| `shelldre:S1192` | `.devcontainer/post-install.sh` | Factor the repeated `--proto '=https' --tlsv1.2` curl flags into a shared array |
| `go:S1135` | `test/e2e/e2e_test.go` | Remove the kubebuilder scaffold TODO placeholder |

All three complexity refactors are behavior-preserving; the `resourceadjuster` change relies on `ParseQuantity` returning an error for empty/invalid recommendations (same skip behavior as the old explicit guards).

## Docs: ephemeral storage as a first-class resource

The README intro previously said Ballast observes only CPU and memory. Now ephemeral storage is named alongside them in the intro, prerequisites, and the `WorkloadProfile` example (which also moves to the current `avg*1.25` / p99 formulas and the 250-sample default). `TESTING.md` notes ephemeral storage comes from the kubelet Summary API with no extra component.

## Verification
- `make lint` — 0 issues
- `make test-coverage-check` — passed, 73.0%
- `make helm-lint` — 0 chart(s) failed; verified the rendered deployment carries ephemeral-storage requests/limits
- `go vet -tags=e2e ./test/e2e/` — clean