### PR TITLE
fix: exempt init and ephemeral containers from measurement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Init and ephemeral containers were being measured.** The metrics API and kubelet summary return a flat container list that does not mark init or ephemeral containers, so the collector recorded samples for them and produced `WorkloadProfile` container entries that could never be applied (apply and resize only patch `spec.containers`). The collector now excludes all init containers and ephemeral debug containers from measurement, reading their names from the profile's pod specs. This is intentionally broad for now: restartable-init "native sidecar" containers are long-running and would be good right-sizing targets, but supporting them requires extending the apply and resize lanes to `spec.initContainers` — tracked in [#30](https://github.com/Tight-Line/ballast/issues/30). Enrollment stays annotation-driven with no Job/CronJob carve-out; docs now steer users away from annotating Job pod specs and toward caution with CronJob pod specs.
+
 ## [0.2.1] - 2026-07-01
 
 ### Fixed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -34,6 +34,10 @@ The following annotation is set by Ballast itself (not by the deployment tool):
 
 The deployment tool also sets the identity tuple labels (see WorkloadProfile below). These are distinct from the behavior annotations.
 
+**Scope of measurement.** Enrollment is a whole-pod, opt-in decision, so deciding *which* workloads to enroll stays with the deployment tool — Ballast does not second-guess it with workload-kind heuristics. In particular there is no built-in Job/CronJob carve-out: a long-running Job may legitimately want right-sizing, so the tool simply should not annotate short-lived Job (or CronJob) pod templates that run to completion.
+
+Within an enrolled pod, Ballast measures and resizes only the regular `spec.containers`. The collector excludes all init containers and ephemeral debug containers from measurement, because the apply and resize paths only ever patch `spec.containers` — sampling anything else would produce recommendations that could never be applied. This is deliberately broader than the ideal end state: restartable-init "native sidecar" containers (`restartPolicy: Always`) are long-running and are legitimate right-sizing targets, so the correct axis is run-to-completion vs long-running rather than init vs regular. Treating restartable-init containers as first-class targets requires extending the apply and resize lanes to patch `spec.initContainers`, which is deferred — tracked in issue #30. Until then, all init containers are excluded.
+
 ---
 
 ## Architecture Overview

--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ spec:
         ballast.tightlinesoftware.com/measure: "true"
 ```
 
+### Which workloads to enroll
+
+Ballast right-sizes **long-running** workloads by learning their steady-state usage over hours or days (default readiness: 250 samples over 24 hours). Enroll Deployments, StatefulSets, DaemonSets, and similar controllers whose pods run continuously.
+
+- **Job pods: you almost certainly do not want to annotate them.** A Job runs to completion, often in seconds or minutes, so it never accumulates enough steady-state history to cross the readiness threshold. Annotating a Job's pod template only creates a `WorkloadProfile` that never produces a recommendation. Ballast will not stop you (opt-in is entirely under your control), but there is nothing to gain and it clutters your profiles.
+- **CronJob pods: think hard before annotating them.** A CronJob creates Jobs, and those Jobs create the pods (`CronJob → Job → Pod`), so CronJob pods carry the same run-to-completion caveat as any other Job pod. Annotate them only if each run is genuinely long-lived and resource-stable enough to measure meaningfully — for example, a multi-hour nightly batch job. A short or spiky periodic task is a poor fit and will mostly generate noise.
+
+**Only regular containers are right-sized today.** Even on an enrolled pod, Ballast measures and resizes only the pod's regular `spec.containers`. It excludes **all init containers and ephemeral debug containers** from measurement — there is no per-container knob to configure; the exclusion is automatic. Note this is broader than ideal: restartable-init "native sidecar" containers (`restartPolicy: Always`) are long-running and would be good right-sizing targets, but they are excluded for now because the apply and resize paths only patch `spec.containers`. Support for right-sizing restartable-init sidecars is tracked in [#30](https://github.com/Tight-Line/ballast/issues/30).
+
 ## Verifying a WorkloadProfile
 
 Once a pod with the `measure` annotation is running, Ballast creates a `WorkloadProfile` for its identity tuple. Check it with:

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -15,6 +15,7 @@ import (
 	"strconv"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,7 +136,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	now := time.Now()
 	tupleHash := store.TupleHash(profile.Status.TupleLabels)
 
-	observed, err := r.collectAllSamples(ctx, tupleHash, profile.Status.SelectorLabels, now, sources)
+	excluded := r.excludedContainerNames(ctx, profile.Status.SelectorLabels)
+
+	observed, err := r.collectAllSamples(ctx, tupleHash, profile.Status.SelectorLabels, now, sources, excluded)
 	if err != nil { // coverage:ignore - Redis error
 		return ctrl.Result{}, err
 	}
@@ -181,6 +184,7 @@ func (r *Reconciler) collectAllSamples(
 	selectorLabels map[string]string,
 	now time.Time,
 	sources map[string]*ballastv1.MetricsSource,
+	excluded map[string]struct{},
 ) (map[string]map[string]struct{}, error) {
 	log := ctrl.LoggerFrom(ctx)
 	observed := make(map[string]map[string]struct{})
@@ -193,7 +197,7 @@ func (r *Reconciler) collectAllSamples(
 			continue
 		}
 
-		additional, err := r.collectFromSource(ctx, tupleHash, selectorLabels, now, sourceName, ms, p)
+		additional, err := r.collectFromSource(ctx, tupleHash, selectorLabels, now, sourceName, ms, p, excluded)
 		if err != nil { // coverage:ignore - Redis error
 			return nil, err
 		}
@@ -222,6 +226,7 @@ func (r *Reconciler) collectFromSource(
 	sourceName string,
 	ms *ballastv1.MetricsSource,
 	p plugin.MetricsPlugin,
+	excluded map[string]struct{},
 ) (map[string]map[string]struct{}, error) {
 	log := ctrl.LoggerFrom(ctx)
 	observed := make(map[string]map[string]struct{})
@@ -236,6 +241,12 @@ func (r *Reconciler) collectFromSource(
 	}
 
 	for _, s := range samples {
+		// Init containers (including restartable-init sidecars) and ephemeral
+		// containers are never measured: apply/resize only touch spec.containers,
+		// so their samples would only produce unactionable recommendations.
+		if _, skip := excluded[s.ContainerName]; skip {
+			continue
+		}
 		markObserved(observed, s.ContainerName, s.Resource)
 
 		if r.dryRunMeasure {
@@ -266,6 +277,57 @@ func (r *Reconciler) writeSample(
 		return fmt.Errorf("adding sample for %s: %w", key, err)
 	}
 	return nil
+}
+
+// excludedContainerNames returns the set of container names that must never be
+// measured for this profile: all init containers and ephemeral (debug)
+// containers. These names come from the pod spec because the metrics API reports
+// a flat container list that does not mark them, and Ballast's apply/resize paths
+// only ever touch spec.containers — so measuring them yields recommendations that
+// can never be applied.
+//
+// TODO(#30): restartable-init "native sidecar" containers (restartPolicy:
+// Always) are long-running and are legitimate right-sizing targets, but are
+// excluded here for now because the apply and resize lanes only patch
+// spec.containers. Supporting them means measuring restartable-init containers
+// AND extending the webhook and resourceadjuster to patch spec.initContainers.
+// Until then, all init containers are excluded.
+//
+// Pods are matched with the profile's selector labels. A List failure is
+// non-fatal: it returns an empty set and logs, leaving measurement unchanged for
+// this cycle rather than failing the reconcile.
+func (r *Reconciler) excludedContainerNames(ctx context.Context, selectorLabels map[string]string) map[string]struct{} {
+	log := ctrl.LoggerFrom(ctx)
+	excluded := make(map[string]struct{})
+
+	// Narrow the List server-side with the concrete labels; LabelAbsent keys
+	// cannot be expressed as MatchingLabels, so they are applied client-side below.
+	matching := client.MatchingLabels{}
+	for k, v := range selectorLabels {
+		if v != plugin.LabelAbsent {
+			matching[k] = v
+		}
+	}
+
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList, matching); err != nil { // coverage:ignore - transient API error
+		log.Error(err, "listing pods to exclude init/ephemeral containers; measuring all reported containers this cycle")
+		return excluded
+	}
+
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if !plugin.MatchesSelector(pod.Labels, selectorLabels) {
+			continue
+		}
+		for j := range pod.Spec.InitContainers {
+			excluded[pod.Spec.InitContainers[j].Name] = struct{}{}
+		}
+		for j := range pod.Spec.EphemeralContainers {
+			excluded[pod.Spec.EphemeralContainers[j].Name] = struct{}{}
+		}
+	}
+	return excluded
 }
 
 // loadSources fetches the MetricsSource CRD for each unique source name referenced in the

--- a/internal/controller/metricscollector/controller_test.go
+++ b/internal/controller/metricscollector/controller_test.go
@@ -373,6 +373,135 @@ func TestReconcile_CollectAndUpdate(t *testing.T) {
 	}
 }
 
+func TestReconcile_ExcludesInitAndEphemeralContainers(t *testing.T) {
+	ctx := context.Background()
+	tupleLabels := map[string]string{"app": "web"}
+	profile := defaultProfile(tupleLabels)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "web"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "app"}},
+			// "init-db" is a run-to-completion init container; "sidecar" is a
+			// restartable-init (native sidecar) that reports live metrics.
+			InitContainers: []corev1.Container{{Name: "init-db"}, {Name: "sidecar"}},
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{EphemeralContainerCommon: corev1.EphemeralContainerCommon{Name: "debugger"}},
+			},
+		},
+	}
+	fc := newFakeClient(defaultPolicy(), defaultMetricsSource(), profile, pod)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	// The plugin reports samples for every container the metrics API sees, including
+	// the init, sidecar, and ephemeral containers — the collector must drop those.
+	p := &mockPlugin{
+		typeName: "kubernetesMetrics",
+		samples: []plugin.ContainerStats{
+			cpuSample("app", 100, now.Add(-2*time.Second)),
+			cpuSample("app", 200, now.Add(-time.Second)),
+			cpuSample("app", 300, now),
+			cpuSample("init-db", 500, now),
+			cpuSample("sidecar", 500, now),
+			cpuSample("debugger", 500, now),
+		},
+	}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+
+	if _, err := reconcileProfile(t, r, "web"); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	tupleHash := store.TupleHash(tupleLabels)
+	appKey := store.MetricKey(tupleHash, "app", "cpu")
+	if count, err := store.SampleCount(ctx, sc, appKey); err != nil {
+		t.Fatalf("SampleCount(app): %v", err)
+	} else if count != 3 {
+		t.Errorf("app sample count: got %d, want 3", count)
+	}
+
+	for _, name := range []string{"init-db", "sidecar", "debugger"} {
+		key := store.MetricKey(tupleHash, name, "cpu")
+		count, err := store.SampleCount(ctx, sc, key)
+		if err != nil {
+			t.Fatalf("SampleCount(%s): %v", name, err)
+		}
+		if count != 0 {
+			t.Errorf("%s sample count: got %d, want 0 (should be excluded from measurement)", name, count)
+		}
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web"}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if len(got.Status.Containers) != 1 {
+		t.Fatalf("status containers: got %d, want 1 (only the app container)", len(got.Status.Containers))
+	}
+	if got.Status.Containers[0].Name != "app" {
+		t.Errorf("status container name: got %q, want %q", got.Status.Containers[0].Name, "app")
+	}
+}
+
+func TestReconcile_ExclusionScopedBySelector(t *testing.T) {
+	ctx := context.Background()
+	// The selector requires "role" to be absent. A pod carrying role=batch is
+	// returned by the server-side app=web filter but rejected client-side, so its
+	// init container must not be treated as an exclusion for this profile.
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+		Status: ballastv1.WorkloadProfileStatus{
+			TupleLabels:    map[string]string{"app": "web"},
+			SelectorLabels: map[string]string{"app": "web", "role": plugin.LabelAbsent},
+		},
+	}
+	matchingPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "web-1", Namespace: "default", Labels: map[string]string{"app": "web"}},
+		Spec:       corev1.PodSpec{InitContainers: []corev1.Container{{Name: "web-init"}}},
+	}
+	otherPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Name: "batch-1", Namespace: "default", Labels: map[string]string{"app": "web", "role": "batch"}},
+		Spec:       corev1.PodSpec{InitContainers: []corev1.Container{{Name: "batch-init"}}},
+	}
+	fc := newFakeClient(defaultPolicy(), defaultMetricsSource(), profile, matchingPod, otherPod)
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, sc := newMiniredisClient(t)
+	now := time.Now()
+	p := &mockPlugin{
+		typeName: "kubernetesMetrics",
+		samples: []plugin.ContainerStats{
+			cpuSample("web-init", 100, now),
+			cpuSample("batch-init", 100, now),
+		},
+	}
+	r := newReconcilerWithPlugin(t, fc, sc, inactiveKS(t), false, p)
+	if _, err := reconcileProfile(t, r, "web"); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	tupleHash := store.TupleHash(profile.Status.TupleLabels)
+	if count, err := store.SampleCount(ctx, sc, store.MetricKey(tupleHash, "web-init", "cpu")); err != nil {
+		t.Fatalf("SampleCount(web-init): %v", err)
+	} else if count != 0 {
+		t.Errorf("web-init: got %d samples, want 0 (init container of a matching pod is excluded)", count)
+	}
+	if count, err := store.SampleCount(ctx, sc, store.MetricKey(tupleHash, "batch-init", "cpu")); err != nil {
+		t.Fatalf("SampleCount(batch-init): %v", err)
+	} else if count != 1 {
+		t.Errorf("batch-init: got %d samples, want 1 (pod not matched by selector, so not an exclusion)", count)
+	}
+}
+
 func TestReconcile_ReadinessNotMet(t *testing.T) {
 	ctx := context.Background()
 	// Policy requires 100 data points — we'll only send 1.

--- a/internal/plugin/kubelet/plugin.go
+++ b/internal/plugin/kubelet/plugin.go
@@ -331,26 +331,11 @@ func (p *Plugin) filterPodsByLabels(pods []PodSummary, selectorLabels map[string
 	out := make([]PodSummary, 0, len(pods))
 	for _, pod := range pods {
 		podLabels := p.podLabels[podKey{Namespace: pod.PodRef.Namespace, Name: pod.PodRef.Name}]
-		if podMatchesSelector(podLabels, selectorLabels) {
+		if plugin.MatchesSelector(podLabels, selectorLabels) {
 			out = append(out, pod)
 		}
 	}
 	return out
-}
-
-func podMatchesSelector(podLabels, selectorLabels map[string]string) bool {
-	for k, v := range selectorLabels {
-		if v == plugin.LabelAbsent {
-			if _, present := podLabels[k]; present {
-				return false
-			}
-		} else {
-			if podLabels[k] != v {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // collectStats builds ContainerStats entries from matching pod summaries.

--- a/internal/plugin/kubernetes/plugin.go
+++ b/internal/plugin/kubernetes/plugin.go
@@ -194,26 +194,11 @@ func filterPods(pods []metricsv1beta1.PodMetrics, selectorLabels map[string]stri
 	}
 	out := make([]metricsv1beta1.PodMetrics, 0, len(pods))
 	for i := range pods {
-		if podMatchesSelector(pods[i].Labels, selectorLabels) {
+		if plugin.MatchesSelector(pods[i].Labels, selectorLabels) {
 			out = append(out, pods[i])
 		}
 	}
 	return out
-}
-
-func podMatchesSelector(podLabels, selectorLabels map[string]string) bool {
-	for k, v := range selectorLabels {
-		if v == plugin.LabelAbsent {
-			if _, present := podLabels[k]; present {
-				return false
-			}
-		} else {
-			if podLabels[k] != v {
-				return false
-			}
-		}
-	}
-	return true
 }
 
 // collect emits one ContainerStats per pod/container/resource combination.

--- a/internal/plugin/matches_selector_test.go
+++ b/internal/plugin/matches_selector_test.go
@@ -1,0 +1,61 @@
+package plugin_test
+
+import (
+	"testing"
+
+	"github.com/tight-line/ballast/internal/plugin"
+)
+
+func TestMatchesSelector(t *testing.T) {
+	tests := []struct {
+		name      string
+		podLabels map[string]string
+		selector  map[string]string
+		want      bool
+	}{
+		{
+			name:      "empty selector matches any pod",
+			podLabels: map[string]string{"app": "web"},
+			selector:  map[string]string{},
+			want:      true,
+		},
+		{
+			name:      "exact match on all keys",
+			podLabels: map[string]string{"app": "web", "env": "prod"},
+			selector:  map[string]string{"app": "web", "env": "prod"},
+			want:      true,
+		},
+		{
+			name:      "value mismatch fails",
+			podLabels: map[string]string{"app": "web"},
+			selector:  map[string]string{"app": "api"},
+			want:      false,
+		},
+		{
+			name:      "missing key fails",
+			podLabels: map[string]string{"app": "web"},
+			selector:  map[string]string{"app": "web", "env": "prod"},
+			want:      false,
+		},
+		{
+			name:      "LabelAbsent matches when key is absent",
+			podLabels: map[string]string{"app": "web"},
+			selector:  map[string]string{"app": "web", "component": plugin.LabelAbsent},
+			want:      true,
+		},
+		{
+			name:      "LabelAbsent fails when key is present",
+			podLabels: map[string]string{"app": "web", "component": "server"},
+			selector:  map[string]string{"app": "web", "component": plugin.LabelAbsent},
+			want:      false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := plugin.MatchesSelector(tc.podLabels, tc.selector); got != tc.want {
+				t.Errorf("MatchesSelector(%v, %v) = %v, want %v", tc.podLabels, tc.selector, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -26,6 +26,24 @@ type MetricsPlugin interface {
 // incorrectly matching a profile whose pod had no component label.
 const LabelAbsent = "--missing--"
 
+// MatchesSelector reports whether podLabels satisfies every requirement in
+// selectorLabels. A value equal to LabelAbsent requires the key to be absent
+// from podLabels; any other value requires an exact match. An empty selector
+// matches every pod. This client-side filter is used because the metrics.k8s.io
+// API ignores label selectors server-side.
+func MatchesSelector(podLabels, selectorLabels map[string]string) bool {
+	for k, v := range selectorLabels {
+		if v == LabelAbsent {
+			if _, present := podLabels[k]; present {
+				return false
+			}
+		} else if podLabels[k] != v {
+			return false
+		}
+	}
+	return true
+}
+
 // WorkloadIdentity holds the label tuple that identifies a WorkloadProfile.
 type WorkloadIdentity struct {
 	Labels map[string]string


### PR DESCRIPTION
## What was wrong

The metrics API and kubelet `/stats/summary` return a **flat** container list that does not mark init or ephemeral containers. So the metrics collector:

- recorded samples for init and ephemeral containers,
- produced `WorkloadProfile` container entries that could never be acted on (apply and resize only patch `spec.containers`), and
- for anything long-running but mistakenly tracked this way, let its readiness hold the whole profile below its `meetsThreshold` gate, blocking apply/resize for the *real* containers.

## The fix

Exclude **all init containers and ephemeral debug containers** from measurement. The collector lists the profile's pods, gathers their `spec.initContainers` and `spec.ephemeralContainers` names, and skips those names when writing samples to Redis and when building status. Pod-list failure is non-fatal.

Apply and resize needed no change: they already only iterate `spec.containers`.

## Known limitation (deferred → #30)

The exclusion is intentionally broad for now. Restartable-init **native sidecar** containers (`restartPolicy: Always`) are long-running and *are* legitimate right-sizing targets — the correct axis is run-to-completion vs long-running, not init vs regular. Treating them as first-class targets means extending the apply (webhook) and resize (resourceadjuster) lanes to patch `spec.initContainers`, which is a larger change. Deferred and tracked in #30; a `TODO(#30)` marks the exclusion site. Until then, all init containers are excluded.

## Deliberately not done: no Job/CronJob carve-out

Enrollment stays annotation-driven. Whether a workload is worth right-sizing is the deployment tool's decision, and `Kind == "Job"` is not a proxy for "run-to-completion" (a long-running Job/CronJob can legitimately want right-sizing). So there is no workload-kind heuristic in the controller. Addressed in docs instead:

- **Job pods: you almost certainly do not want to annotate them.**
- **CronJob pods: think hard before annotating them** (`CronJob → Job → Pod`, same run-to-completion caveat).

## Also

Extracts the `LabelAbsent`-aware selector match into `plugin.MatchesSelector`, now shared by both metrics plugins and the collector (was duplicated).

## Docs / changelog

- `README.md` — "Which workloads to enroll" (Job/CronJob guidance) + note that only regular containers are right-sized today, sidecars tracked in #30.
- `DESIGN.md` — "Scope of measurement" rationale.
- `CHANGELOG.md` — `[Unreleased]` entry.

## Tests

- init / restartable-init sidecar / ephemeral samples are dropped while the real container is still measured
- exclusion is correctly scoped by the profile selector
- table test for `plugin.MatchesSelector`

`make lint` (0 issues) and `make test-coverage-check` (73.1%, gate passed) both green.