### PR TITLE
fix: kubeletSummary node cache lockout and retry rate-gating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`kubeletSummary` could permanently lose a healthy node's metrics after a transient kubelet blip.** Each node's `/stats/summary` is cached per-node (`CacheTTL` 55s); once an entry aged past `2*CacheTTL`, the staleness check returned before attempting any refresh, so `fetchTime` never advanced and the node was skipped forever, emitting `skipping node: summary too stale` on every scrape with an ever-growing `age` even after the kubelet recovered. A refresh is now attempted on every call past `CacheTTL`; the staleness gate only governs whether cached data is served as a fallback when that refresh fails. A node that has recovered heals on the next scrape.
+- **`kubeletSummary` could permanently lose a healthy node's metrics after a transient kubelet blip.** Each node's `/stats/summary` is cached per-node (`CacheTTL` 55s); once an entry aged past `2*CacheTTL`, the staleness check returned before attempting any refresh, so `fetchTime` never advanced and the node was skipped forever, emitting `skipping node: summary too stale` on every scrape with an ever-growing `age` even after the kubelet recovered. A refresh is now attempted whenever the cache is past `CacheTTL`; the staleness gate only governs whether cached data is served as a fallback when that refresh fails. A node that has recovered heals within one `CacheTTL` of the kubelet coming back.
+
+- **`kubeletSummary` had no rate limit on retries against a failing node.** Fetch failures on a previously-cached node return stale data rather than a hard error, so the per-workload backoff never engaged for them. Combined with the recovery fix above, a down kubelet would have been re-probed once per enrolled workload every scrape. Each node now carries a `lastAttempt` timestamp that gates refreshes to at most one probe per `CacheTTL` per node, regardless of how many workload identities scrape in a cycle.
 
 ## [0.2.2] - 2026-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`kubeletSummary` could permanently lose a healthy node's metrics after a transient kubelet blip.** Each node's `/stats/summary` is cached per-node (`CacheTTL` 55s); once an entry aged past `2*CacheTTL`, the staleness check returned before attempting any refresh, so `fetchTime` never advanced and the node was skipped forever, emitting `skipping node: summary too stale` on every scrape with an ever-growing `age` even after the kubelet recovered. A refresh is now attempted on every call past `CacheTTL`; the staleness gate only governs whether cached data is served as a fallback when that refresh fails. A node that has recovered heals on the next scrape.
+
 ## [0.2.2] - 2026-07-01
 
 ### Fixed

--- a/internal/plugin/kubelet/plugin.go
+++ b/internal/plugin/kubelet/plugin.go
@@ -247,8 +247,11 @@ func (p *Plugin) FetchStats(ctx context.Context, id plugin.WorkloadIdentity, _ p
 }
 
 // nodeData returns the pod summaries for nodeName, using the cache when fresh.
-// On refresh failure it falls back to stale data if age < 2*CacheTTL, logging a
-// warning. When age >= 2*CacheTTL it logs a warning and skips the node (nil, nil).
+// When the cache is fresh (age < CacheTTL) it is served directly. Otherwise a
+// refresh is always attempted; only if that refresh fails does the staleness gate
+// apply: cached pods are served as a fallback while age < 2*CacheTTL, and the node
+// is skipped (nil, nil) once age >= 2*CacheTTL. A refresh is attempted on every
+// call past CacheTTL, so a node that has recovered always heals on the next scrape.
 // Returns a non-nil error only when there is no usable data at all.
 func (p *Plugin) nodeData(ctx context.Context, nodeName string, now time.Time) ([]PodSummary, error) {
 	// Get or lazily create the entry; nodeCacheMu only protects the map, not the
@@ -264,28 +267,24 @@ func (p *Plugin) nodeData(ctx context.Context, nodeName string, now time.Time) (
 	entry.mu.Lock()
 	defer entry.mu.Unlock()
 
-	if p.opts.CacheTTL > 0 && !entry.fetchTime.IsZero() {
-		age := now.Sub(entry.fetchTime)
+	if p.opts.CacheTTL > 0 && !entry.fetchTime.IsZero() && now.Sub(entry.fetchTime) < p.opts.CacheTTL {
+		return entry.pods, nil
+	}
 
-		if age >= 2*p.opts.CacheTTL {
+	// Cache is stale (or absent): always attempt a refresh. The staleness gate only
+	// governs the fallback path below, so it can never block a node from re-fetching.
+	s, err := p.fetcher.Fetch(ctx, nodeName)
+	if err != nil {
+		if entry.fetchTime.IsZero() {
+			return nil, err
+		}
+		if age := now.Sub(entry.fetchTime); age >= 2*p.opts.CacheTTL {
 			p.log.Info("skipping node: summary too stale; metrics for this node will be missing",
 				"node", nodeName, "age", age.Round(time.Second), "limit", 2*p.opts.CacheTTL)
 			return nil, nil
 		}
-
-		if age < p.opts.CacheTTL {
-			return entry.pods, nil
-		}
-		// age in [CacheTTL, 2*CacheTTL): attempt refresh, fall back to stale on error.
-	}
-
-	s, err := p.fetcher.Fetch(ctx, nodeName)
-	if err != nil {
-		if !entry.fetchTime.IsZero() {
-			p.log.Error(err, "node summary fetch failed; using stale data", "node", nodeName)
-			return entry.pods, nil
-		}
-		return nil, err
+		p.log.Error(err, "node summary fetch failed; using stale data", "node", nodeName)
+		return entry.pods, nil
 	}
 
 	entry.fetchTime = now

--- a/internal/plugin/kubelet/plugin.go
+++ b/internal/plugin/kubelet/plugin.go
@@ -91,9 +91,15 @@ type backoffEntry struct {
 // nodeCacheEntry holds the per-node summary with a mutex that serializes concurrent
 // refreshes for the same node without blocking other nodes.
 type nodeCacheEntry struct {
-	mu        sync.Mutex
+	mu sync.Mutex
+	// fetchTime is when pods were last fetched successfully; it drives the staleness
+	// gate (serve fresh, fall back to stale, or skip).
 	fetchTime time.Time
-	pods      []PodSummary
+	// lastAttempt is when a fetch was last attempted (success or failure). It rate-gates
+	// retries so a failing kubelet is probed at most once per CacheTTL per node, no matter
+	// how many workload identities scrape in a cycle.
+	lastAttempt time.Time
+	pods        []PodSummary
 }
 
 type podKey struct {
@@ -247,11 +253,12 @@ func (p *Plugin) FetchStats(ctx context.Context, id plugin.WorkloadIdentity, _ p
 }
 
 // nodeData returns the pod summaries for nodeName, using the cache when fresh.
-// When the cache is fresh (age < CacheTTL) it is served directly. Otherwise a
-// refresh is always attempted; only if that refresh fails does the staleness gate
-// apply: cached pods are served as a fallback while age < 2*CacheTTL, and the node
-// is skipped (nil, nil) once age >= 2*CacheTTL. A refresh is attempted on every
-// call past CacheTTL, so a node that has recovered always heals on the next scrape.
+// When the cache is fresh (age < CacheTTL) it is served directly. Otherwise a refresh
+// is attempted, rate-gated to at most once per CacheTTL per node so a failing kubelet
+// is not re-hit once per workload every scrape. When a refresh is unavailable (it
+// failed or the gate is closed) the staleness gate applies: cached pods are served
+// while age < 2*CacheTTL, and the node is skipped (nil, nil) once age >= 2*CacheTTL.
+// A recovered node heals within one CacheTTL of the kubelet coming back.
 // Returns a non-nil error only when there is no usable data at all.
 func (p *Plugin) nodeData(ctx context.Context, nodeName string, now time.Time) ([]PodSummary, error) {
 	// Get or lazily create the entry; nodeCacheMu only protects the map, not the
@@ -271,25 +278,45 @@ func (p *Plugin) nodeData(ctx context.Context, nodeName string, now time.Time) (
 		return entry.pods, nil
 	}
 
-	// Cache is stale (or absent): always attempt a refresh. The staleness gate only
-	// governs the fallback path below, so it can never block a node from re-fetching.
+	// Rate-gate refresh attempts: probe a node at most once per CacheTTL, whether the
+	// last attempt succeeded or failed. Without this, a failing kubelet would be re-hit
+	// once per enrolled workload every scrape, since the per-node cache is shared across
+	// workload identities but FetchStats runs per identity.
+	if p.opts.CacheTTL > 0 && !entry.lastAttempt.IsZero() && now.Sub(entry.lastAttempt) < p.opts.CacheTTL {
+		return p.cachedOrSkip(entry, nodeName, now), nil
+	}
+
+	// Cache is stale (or absent) and the retry gate is open: attempt a refresh. The
+	// staleness gate only governs the fallback path, so it can never block a re-fetch.
+	entry.lastAttempt = now
 	s, err := p.fetcher.Fetch(ctx, nodeName)
 	if err != nil {
 		if entry.fetchTime.IsZero() {
 			return nil, err
 		}
-		if age := now.Sub(entry.fetchTime); age >= 2*p.opts.CacheTTL {
-			p.log.Info("skipping node: summary too stale; metrics for this node will be missing",
-				"node", nodeName, "age", age.Round(time.Second), "limit", 2*p.opts.CacheTTL)
-			return nil, nil
-		}
 		p.log.Error(err, "node summary fetch failed; using stale data", "node", nodeName)
-		return entry.pods, nil
+		return p.cachedOrSkip(entry, nodeName, now), nil
 	}
 
 	entry.fetchTime = now
 	entry.pods = s.Pods
 	return s.Pods, nil
+}
+
+// cachedOrSkip decides what to serve when a fresh fetch is unavailable (it failed, or was
+// suppressed by the retry gate). It serves the last successful pods while their age is
+// under 2*CacheTTL, and skips the node (nil) once age reaches 2*CacheTTL. With no prior
+// success there is nothing to serve, so it skips silently.
+func (p *Plugin) cachedOrSkip(entry *nodeCacheEntry, nodeName string, now time.Time) []PodSummary {
+	if entry.fetchTime.IsZero() {
+		return nil
+	}
+	if age := now.Sub(entry.fetchTime); age >= 2*p.opts.CacheTTL {
+		p.log.Info("skipping node: summary too stale; metrics for this node will be missing",
+			"node", nodeName, "age", age.Round(time.Second), "limit", 2*p.opts.CacheTTL)
+		return nil
+	}
+	return entry.pods
 }
 
 // refreshPodLabels fetches all pods cluster-wide and rebuilds the label map when the

--- a/internal/plugin/kubelet/plugin_test.go
+++ b/internal/plugin/kubelet/plugin_test.go
@@ -450,6 +450,59 @@ func TestFetchStats_VeryStaleCache_SkipsNode(t *testing.T) {
 	}
 }
 
+// TestFetchStats_VeryStaleCache_RecoversWhenFetcherHeals is a regression test for a
+// cache-lockout bug: once a node's cache aged past 2*CacheTTL, the staleness check
+// used to return before attempting any refresh, so fetchTime never advanced and the
+// node was skipped forever even after the kubelet recovered. A refresh must be
+// attempted on every call past CacheTTL, so a healed node heals on the next scrape.
+func TestFetchStats_VeryStaleCache_RecoversWhenFetcherHeals(t *testing.T) {
+	nodes := &fakeNodeLister{nodes: []corev1.Node{node("n1")}}
+	pods := &fakePodLister{pods: []corev1.Pod{
+		pod("default", "web-1", map[string]string{"app": "web"}),
+	}}
+	summary := map[string]*kplugin.NodeSummary{
+		"n1": {Pods: []kplugin.PodSummary{
+			{PodRef: kplugin.PodRef{Namespace: "default", Name: "web-1"},
+				EphemeralStorage: &kplugin.StorageStats{UsedBytes: usedBytes(999)},
+				Containers:       []kplugin.ContainerRef{{Name: "app"}}},
+		}},
+	}
+	fetcher := &fakeSummaryFetcher{summaries: summary}
+	p := kplugin.NewWithDeps(nodes, pods, fetcher,
+		kplugin.Options{MaxBackoff: 10 * time.Second, CacheTTL: time.Millisecond},
+		logr.Discard())
+	id := plugin.WorkloadIdentity{Labels: map[string]string{"app": "web"}}
+
+	// Populate cache.
+	if _, err := p.FetchStats(context.Background(), id, plugin.TimeWindow{}); err != nil {
+		t.Fatalf("initial call: %v", err)
+	}
+
+	// Let the cache age past 2*CacheTTL while the fetcher is failing, so the node is
+	// skipped and (under the old logic) its cache entry would be frozen forever.
+	time.Sleep(10 * time.Millisecond)
+	fetcher.err = errors.New("kubelet unreachable")
+	fetcher.summaries = nil
+	stats, err := p.FetchStats(context.Background(), id, plugin.TimeWindow{})
+	if err != nil {
+		t.Fatalf("expected skipped node (no error) while stale and failing, got: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Fatalf("expected node skipped while very stale and failing, got %d stats", len(stats))
+	}
+
+	// The kubelet recovers. The very next scrape must re-fetch and return fresh data.
+	fetcher.err = nil
+	fetcher.summaries = summary
+	stats, err = p.FetchStats(context.Background(), id, plugin.TimeWindow{})
+	if err != nil {
+		t.Fatalf("expected recovery after fetcher healed, got error: %v", err)
+	}
+	if len(stats) != 1 {
+		t.Errorf("expected node to recover with 1 stat entry once fetcher healed, got %d", len(stats))
+	}
+}
+
 func TestFetchStats_BackoffReset(t *testing.T) {
 	nodes := &fakeNodeLister{err: errors.New("fail")}
 	pods := &fakePodLister{}

--- a/internal/plugin/kubelet/plugin_test.go
+++ b/internal/plugin/kubelet/plugin_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -47,20 +48,44 @@ func (f *fakePodLister) List(_ context.Context, _ metav1.ListOptions) (*corev1.P
 }
 
 type fakeSummaryFetcher struct {
+	mu sync.Mutex
 	// summaries maps nodeName -> summary to return (nil = not found)
 	summaries map[string]*kplugin.NodeSummary
 	err       error
+	// calls counts Fetch invocations per node (guarded by mu; FetchStats fans out
+	// to nodes concurrently).
+	calls map[string]int
 }
 
 func (f *fakeSummaryFetcher) Fetch(_ context.Context, nodeName string) (*kplugin.NodeSummary, error) {
-	if f.err != nil {
-		return nil, f.err
+	f.mu.Lock()
+	if f.calls == nil {
+		f.calls = make(map[string]int)
 	}
+	f.calls[nodeName]++
+	err := f.err
 	s, ok := f.summaries[nodeName]
+	f.mu.Unlock()
+
+	if err != nil {
+		return nil, err
+	}
 	if !ok {
 		return &kplugin.NodeSummary{}, nil
 	}
 	return s, nil
+}
+
+func (f *fakeSummaryFetcher) callCount(nodeName string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls[nodeName]
+}
+
+func (f *fakeSummaryFetcher) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
 }
 
 // ---- helpers ----
@@ -491,7 +516,10 @@ func TestFetchStats_VeryStaleCache_RecoversWhenFetcherHeals(t *testing.T) {
 		t.Fatalf("expected node skipped while very stale and failing, got %d stats", len(stats))
 	}
 
-	// The kubelet recovers. The very next scrape must re-fetch and return fresh data.
+	// The kubelet recovers. Wait past CacheTTL so the retry gate is open again, then the
+	// next scrape must re-fetch and return fresh data even though the cache is still very
+	// stale (the recovery path the lockout bug prevented).
+	time.Sleep(2 * time.Millisecond)
 	fetcher.err = nil
 	fetcher.summaries = summary
 	stats, err = p.FetchStats(context.Background(), id, plugin.TimeWindow{})
@@ -500,6 +528,98 @@ func TestFetchStats_VeryStaleCache_RecoversWhenFetcherHeals(t *testing.T) {
 	}
 	if len(stats) != 1 {
 		t.Errorf("expected node to recover with 1 stat entry once fetcher healed, got %d", len(stats))
+	}
+}
+
+// TestFetchStats_FailingNode_RetryGatedPerCacheTTL asserts the per-node retry gate: when a
+// node's kubelet is failing, repeated FetchStats calls (as happens once per enrolled
+// workload identity every scrape) must not each re-probe the kubelet. Within one CacheTTL
+// the failing node is fetched at most once; a new probe is only allowed after CacheTTL.
+func TestFetchStats_FailingNode_RetryGatedPerCacheTTL(t *testing.T) {
+	nodes := &fakeNodeLister{nodes: []corev1.Node{node("n1")}}
+	pods := &fakePodLister{pods: []corev1.Pod{
+		pod("default", "web-1", map[string]string{"app": "web"}),
+	}}
+	summary := map[string]*kplugin.NodeSummary{
+		"n1": {Pods: []kplugin.PodSummary{
+			{PodRef: kplugin.PodRef{Namespace: "default", Name: "web-1"},
+				EphemeralStorage: &kplugin.StorageStats{UsedBytes: usedBytes(999)},
+				Containers:       []kplugin.ContainerRef{{Name: "app"}}},
+		}},
+	}
+	fetcher := &fakeSummaryFetcher{summaries: summary}
+	// CacheTTL=50ms: short enough to go stale via a sleep, long enough that the burst of
+	// calls below all completes within one TTL window.
+	p := kplugin.NewWithDeps(nodes, pods, fetcher,
+		kplugin.Options{MaxBackoff: 10 * time.Second, CacheTTL: 50 * time.Millisecond},
+		logr.Discard())
+	id := plugin.WorkloadIdentity{Labels: map[string]string{"app": "web"}}
+
+	// Populate the cache (fetch #1), then let the kubelet start failing.
+	if _, err := p.FetchStats(context.Background(), id, plugin.TimeWindow{}); err != nil {
+		t.Fatalf("initial call: %v", err)
+	}
+	if got := fetcher.callCount("n1"); got != 1 {
+		t.Fatalf("expected 1 fetch after populating cache, got %d", got)
+	}
+	fetcher.setErr(errors.New("kubelet unreachable"))
+
+	// Let the cache go stale (age > CacheTTL) so refreshes are attempted, and fire a burst
+	// of calls modeling many workload identities scraping within one TTL window. Only the
+	// first should probe the failing kubelet (fetch #2); the rest are gated and serve stale.
+	time.Sleep(60 * time.Millisecond)
+	for i := range 20 {
+		stats, err := p.FetchStats(context.Background(), id, plugin.TimeWindow{})
+		if err != nil {
+			t.Fatalf("call %d unexpectedly errored: %v", i, err)
+		}
+		if len(stats) != 1 {
+			t.Fatalf("call %d: expected stale data served while gated, got %d stats", i, len(stats))
+		}
+	}
+	if got := fetcher.callCount("n1"); got != 2 {
+		t.Errorf("expected failing node probed at most once per CacheTTL (2 total fetches), got %d", got)
+	}
+}
+
+// TestFetchStats_FailingNode_NoCache_SecondWorkloadGated covers the no-prior-success arm
+// of the retry gate: a node whose very first fetch fails records an attempt but no cache.
+// A second workload identity scraping the same node within CacheTTL must be gated (serve
+// nothing, no re-probe) rather than re-hitting the failing kubelet.
+func TestFetchStats_FailingNode_NoCache_SecondWorkloadGated(t *testing.T) {
+	nodes := &fakeNodeLister{nodes: []corev1.Node{node("n1")}}
+	pods := &fakePodLister{pods: []corev1.Pod{
+		pod("default", "web-1", map[string]string{"app": "web"}),
+		pod("default", "api-1", map[string]string{"app": "api"}),
+	}}
+	fetcher := &fakeSummaryFetcher{err: errors.New("kubelet unreachable")}
+	p := kplugin.NewWithDeps(nodes, pods, fetcher,
+		kplugin.Options{MaxBackoff: 10 * time.Second, CacheTTL: time.Hour},
+		logr.Discard())
+
+	// Workload A: node has no cache and the fetch fails, so FetchStats errors (and A backs
+	// off). This records lastAttempt on the node without ever setting fetchTime.
+	_, err := p.FetchStats(context.Background(),
+		plugin.WorkloadIdentity{Labels: map[string]string{"app": "web"}}, plugin.TimeWindow{})
+	if err == nil {
+		t.Fatal("expected error for uncached failing node")
+	}
+	if got := fetcher.callCount("n1"); got != 1 {
+		t.Fatalf("expected exactly 1 fetch attempt, got %d", got)
+	}
+
+	// Workload B (different identity, not backed off) scrapes the same node within CacheTTL.
+	// The gate is closed and there is no cache, so it serves nothing without re-probing.
+	stats, err := p.FetchStats(context.Background(),
+		plugin.WorkloadIdentity{Labels: map[string]string{"app": "api"}}, plugin.TimeWindow{})
+	if err != nil {
+		t.Fatalf("workload B should not error while gated, got: %v", err)
+	}
+	if len(stats) != 0 {
+		t.Errorf("expected no stats for uncached gated node, got %d", len(stats))
+	}
+	if got := fetcher.callCount("n1"); got != 1 {
+		t.Errorf("expected gated second workload not to re-probe (still 1 fetch), got %d", got)
 	}
 }
 


### PR DESCRIPTION
## What was wrong

A production `kubeletSummary` log showed a healthy node being skipped forever:

```
"msg":"skipping node: summary too stale; metrics for this node will be missing","node":"dev-lgl-k8sw9...","age":22489,"limit":110
```

`age` climbed one second at a time for hours while the node was `Ready`. Two coupled bugs:

### 1. Permanent cache lockout (recovery bug)

Each node's `/stats/summary` is cached per-node (`CacheTTL` 55s). Once an entry aged past `2*CacheTTL` (110s), the staleness check in `nodeData` returned `nil, nil` **before** attempting any refresh. `fetchTime` is only advanced on a successful fetch, so the entry could never refresh: `age` grew unbounded and the node was skipped forever, even after the kubelet recovered. A ~1-minute fetch blip was enough to poison a node for good.

### 2. No retry rate limit against a failing node (backoff gap)

Fetch failures on a *previously-cached* node return stale data rather than a hard error, so the per-workload exponential backoff never engaged for them (unlike the `kubernetesMetrics` plugin, which also has a shared cache-timestamp guard and a global rate limiter). On its own this was masked by the very-stale branch that stopped fetching; fixing bug #1 removed that accidental circuit breaker, so a down kubelet would be re-probed **once per enrolled workload every scrape** (the ~10 events/sec in the log).

## The fix

- **Recovery:** attempt a refresh whenever the cache is past `CacheTTL`. The staleness gate now only decides whether stale data is served as a *fallback* when a fresh fetch is unavailable. A recovered node heals within one `CacheTTL`.
- **Rate-gating:** each `nodeCacheEntry` carries a `lastAttempt` timestamp (stamped on every attempt, success or failure). Refreshes are gated to at most one probe per `CacheTTL` per node, regardless of how many workload identities scrape in a cycle. This restores the request-rate protection `kubernetesMetrics` already had.

## Tests

Three new tests, all green under `-race`:

- recovery after a very-stale + failing window (fails against the old code: `got 0` stats)
- a failing node is probed at most once per `CacheTTL` across a burst of scrapes
- a second workload hitting an uncached failing node is gated rather than re-probing

`make lint` clean; `make test-coverage-check` green (kubelet pkg 98.5%).

## Notes

Unrelated to the v0.2.1 `nodes is forbidden` RBAC fix (that was a missing `list` verb; this is downstream caching). No `IMPLEMENTATION_PLAN.md` / `README.md` status change: Phase 14 (`kubeletSummary`) is already Complete and these are bug fixes to the shipped plugin.