### PR TITLE
Add 20% headroom to default policy limits; retire the implementation plan tracker

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,8 @@
 
 > This file is the primary entry point for AI agents working on ballast.
 > Read DESIGN.md for full system context before making changes.
-> Read IMPLEMENTATION_PLAN.md to find the current phase and key files.
+> The Key Files table below is the current reference. IMPLEMENTATION_PLAN.md is a
+> historical record of the phased build-out, not a live status tracker.
 
 ## Project Overview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Default policy limits now carry 20% headroom instead of sizing at the observed peak.** The `homogeneous-large-fleet` default `ClusterResourcePolicy` set its memory and ephemeral-storage limits at `p99` with no headroom, which OOMKilled (or evicted) any pod that exceeded its observed p99 — including legitimate rare spikes whose true peak was never in the sample window. Both limits are now `p99 * 1.2`: the 20% margin absorbs a normal spike while still catching a genuine leak or runaway. Requests (`avg * 1.25`) and the intentionally-omitted CPU limit are unchanged. The `local-testing` preset's memory limit follows suit.
+
 ### Fixed
 
 - **`kubeletSummary` could permanently lose a healthy node's metrics after a transient kubelet blip.** Each node's `/stats/summary` is cached per-node (`CacheTTL` 55s); once an entry aged past `2*CacheTTL`, the staleness check returned before attempting any refresh, so `fetchTime` never advanced and the node was skipped forever, emitting `skipping node: summary too stale` on every scrape with an ever-growing `age` even after the kubelet recovered. A refresh is now attempted whenever the cache is past `CacheTTL`; the staleness gate only governs whether cached data is served as a fallback when that refresh fails. A node that has recovered heals within one `CacheTTL` of the kubelet coming back.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,14 +1,5 @@
 # Ballast — Claude Code Instructions
 
-## Status sync at end of each PR
-
-Before opening or finalizing a PR, keep these two files consistent with each other and with the actual implementation status:
-
-- `IMPLEMENTATION_PLAN.md` — update the phase `Status:` line to `[x]` (complete) or `[~]` (PR open) and fill in the PR link
-- `README.md` — update the Implementation Status table to match
-
-Rule: if all features of a phase are done and a PR is open, mark the phase complete (`[x]` / "Complete"). PRs are only opened once the feature set is finished.
-
 ## Lint + coverage gate: required before every commit
 
 A commit is not complete until all of these pass:

--- a/README.md
+++ b/README.md
@@ -185,10 +185,10 @@ status:
           request: "288m"     # avg * 1.25 headroom
         memory:
           request: "225Mi"    # avg * 1.25 headroom
-          limit: "240Mi"      # p99
+          limit: "288Mi"      # p99 * 1.2
         ephemeral-storage:
           request: "1200Mi"   # p90
-          limit: "1800Mi"     # p99
+          limit: "2160Mi"     # p99 * 1.2
   meetsThreshold: true
   activeWorkloads: 3
 ```
@@ -298,7 +298,7 @@ spec:
       field: limit
       source: kubernetes-metrics
       aggregation: p99
-      headroom: "1.0"
+      headroom: "1.2"
     - resource: ephemeral-storage
       field: request
       source: kubelet-summary
@@ -308,7 +308,7 @@ spec:
       field: limit
       source: kubelet-summary
       aggregation: p99
-      headroom: "1.0"
+      headroom: "1.2"
   readiness:
     minDataPoints: 250
     minTimeSpan: "24h"
@@ -324,8 +324,8 @@ spec:
 This catch-all policy applies to every opted-in pod in the cluster. Key design decisions:
 
 - **Requests at `avg * 1.25`.** Sizing CPU and memory requests at 80% of mean (= mean / 0.80 target utilization) keeps nodes dense while leaving headroom for normal variation. For a large homogeneous fleet the aggregate pressure is predictable, so the mean is a reliable basis.
-- **Memory limit at p99, no headroom.** p99 is the highest usage the workload has shown in production; a pod exceeding it is likely leaking and should be OOMKilled. This yields Burstable QoS (limit > request), the right class for most production workloads. **CPU limits are intentionally omitted** — they cause throttling rather than reclaiming waste.
-- **Ephemeral storage from the kubelet Summary API.** The request is sized at p90 (the growth-skewed distribution) and the limit at p99 so the kubelet evicts a runaway pod before the node hits disk pressure.
+- **Memory limit at `p99 * 1.2`.** p99 is the highest usage the workload has shown in production; the 20% headroom absorbs a normal rare spike while still OOMKilling a pod that runs well past its observed peak (a likely leak). This yields Burstable QoS (limit > request), the right class for most production workloads. **CPU limits are intentionally omitted** — they cause throttling rather than reclaiming waste.
+- **Ephemeral storage from the kubelet Summary API.** The request is sized at p90 (the growth-skewed distribution) and the limit at `p99 * 1.2` so the kubelet evicts a genuine runaway pod before the node hits disk pressure while tolerating a normal spike above the observed peak.
 - **250 samples over 24 hours before acting.** At the 5-minute poll interval a single long-running pod accrues ~288 samples in 24h, so the 24h window — not the sample count — is the binding constraint. A high coefficient of variation (CV > 1.5) also blocks action — it means the workload is too spiky to size reliably.
 - **20% drift threshold.** A resize only fires when the current resource value deviates from the recommendation by more than 20%, avoiding churn from minor fluctuations.
 - **50% max change per cycle.** Caps how aggressively a single resize can move a value, giving workloads time to stabilize between adjustments.

--- a/README.md
+++ b/README.md
@@ -18,26 +18,6 @@ Workloads opt in with annotations on their pod templates. Ballast observes real 
 
 Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](https://github.com/kubernetes-sigs/descheduler) — see the Annotation Contract section for details.
 
-## Implementation Status
-
-| Phase | What | Status |
-|---|---|---|
-| 1 | Repository scaffold, kubebuilder init, CI/CD | Complete |
-| 2 | CRD type definitions | Complete |
-| 3 | Logger infrastructure and kill switch | Complete |
-| 4 | Policy resolution | Complete |
-| 5 | Redis/Valkey client layer | Complete |
-| 6 | Plugin interface and `kubernetesMetrics` plugin | Complete |
-| 7 | WorkloadWatcher controller | Complete |
-| 8 | MetricsCollector controller | Complete |
-| 9 | Admission webhook | Complete |
-| 10 | ResourceAdjuster controller | Complete |
-| 11 | Helm chart | Complete |
-| 12 | Polish and release readiness | Complete |
-| 13 | Prometheus and OpenTelemetry metrics | Complete |
-| 14 | `kubeletSummary` plugin (ephemeral storage) | Complete |
-| 15 | Updated default policy, memory/ephemeral limits, policy presets | Complete |
-
 ## Prerequisites
 
 - Kubernetes 1.35+ (required for in-place pod resize; earlier versions support measure and apply but not resize)

--- a/charts/ballast/presets/README.md
+++ b/charts/ballast/presets/README.md
@@ -20,7 +20,7 @@ helm upgrade --install ballast ./charts/ballast \
 
 | Preset | File | Use case |
 | --- | --- | --- |
-| `homogeneous-large-fleet` | _(built-in default in `values.yaml`)_ | Production fleets of many similar pods. Sizes requests at `avg * 1.25`, memory limit at p99, and ephemeral storage from the kubelet Summary API. Polls every 5m and requires 250 samples over 24h before acting. |
+| `homogeneous-large-fleet` | _(built-in default in `values.yaml`)_ | Production fleets of many similar pods. Sizes requests at `avg * 1.25`, memory limit at `p99 * 1.2`, and ephemeral storage from the kubelet Summary API. Polls every 5m and requires 250 samples over 24h before acting. |
 | `local-testing` | `local-testing.yaml` | Local kind clusters. Polls every 15s and acts after 5 samples over 1m with a 30s resize interval, so you can watch a workload become eligible and get resized within minutes. **Never use in production.** |
 
 The `homogeneous-large-fleet` preset is the chart's built-in default, so a plain

--- a/charts/ballast/presets/local-testing.yaml
+++ b/charts/ballast/presets/local-testing.yaml
@@ -38,7 +38,7 @@ defaultClusterResourcePolicy:
     - resource: memory
       field: limit
       aggregation: p99
-      headroom: "1.0"
+      headroom: "1.2"
   readiness:
     minDataPoints: 5
     minTimeSpan: "1m"

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -138,8 +138,9 @@ telemetry:
 # defaultClusterResourcePolicy installs a catch-all policy that applies to all
 # opted-in pods. The values below are the "homogeneous-large-fleet" preset: it
 # sizes CPU and memory requests at avg * 1.25 (= mean / 0.80 target utilization),
-# sets a memory limit at p99, and sizes ephemeral storage requests/limits from the
-# kubelet Summary API. It requires 500 samples over 24 hours before acting.
+# sets a memory limit at p99 + 20% headroom, and sizes ephemeral storage
+# requests/limits from the kubelet Summary API. It requires 250 samples over 24
+# hours before acting.
 #
 # This is the built-in default preset. Other presets ship as values overlays under
 # charts/ballast/presets/ (see presets/README.md) and are selected at install time
@@ -165,11 +166,12 @@ defaultClusterResourcePolicy:
   #
   # Requests are sized at avg * 1.25: for a large homogeneous fleet the aggregate
   # pressure is predictable, so sizing at 80% of mean keeps nodes dense while
-  # leaving headroom for normal variation. The memory limit is set at p99 (the
-  # highest usage seen in production) with no headroom — a pod that exceeds p99 is
-  # likely leaking and should be OOMKilled. This yields Burstable QoS (limit >
-  # request), the right class for most production workloads. CPU limits are
-  # intentionally omitted: they cause throttling rather than reclaiming waste.
+  # leaving headroom for normal variation. The memory limit is set at p99 * 1.2:
+  # p99 is the highest usage seen in production, and the 20% headroom absorbs a
+  # normal rare spike while still OOMKilling a pod that runs well past its observed
+  # peak (a likely leak). This yields Burstable QoS (limit > request), the right
+  # class for most production workloads. CPU limits are intentionally omitted:
+  # they cause throttling rather than reclaiming waste.
   metrics:
     - resource: cpu
       field: request
@@ -182,10 +184,11 @@ defaultClusterResourcePolicy:
     - resource: memory
       field: limit
       aggregation: p99
-      headroom: "1.0"
+      headroom: "1.2"
     # Ephemeral-storage entries read from the kubelet Summary API. The request is
-    # sized at p90 (the growth-skewed distribution) and the limit at p99 so the
-    # kubelet evicts a runaway pod before the node hits disk pressure.
+    # sized at p90 (the growth-skewed distribution) and the limit at p99 * 1.2 so
+    # the kubelet evicts a genuine runaway pod before the node hits disk pressure
+    # while tolerating a normal spike above the observed peak.
     - resource: ephemeral-storage
       field: request
       source: kubelet-summary
@@ -195,7 +198,7 @@ defaultClusterResourcePolicy:
       field: limit
       source: kubelet-summary
       aggregation: p99
-      headroom: "1.0"
+      headroom: "1.2"
   readiness:
     # minDataPoints is the minimum number of samples before Ballast will act.
     # Sized against the 5m poll interval above: a single pod running 24h accrues


### PR DESCRIPTION
Two unrelated changes on one branch.

## 1. Default policy limits carry 20% headroom (`feat`)

The `homogeneous-large-fleet` default `ClusterResourcePolicy` sized its memory and ephemeral-storage **limits** at `p99` with **no headroom**. As a fleet-wide catch-all that OOMKilled (or, for eph-storage, evicted) any pod that exceeded its *observed* p99 — including legitimate rare spikes whose true peak was never in the sample window.

Both limits are now **`p99 * 1.2`**: the 20% margin absorbs a normal spike while still catching a genuine leak or runaway. Requests (`avg * 1.25`) and the intentionally-omitted CPU limit are unchanged.

Kept consistent across `charts/ballast/values.yaml`, the `local-testing` preset, `presets/README.md`, and the README (values example + worked numbers 240Mi→288Mi / 1800Mi→2160Mi + design notes). Also corrected a stale "500 samples" reference to the actual 250.

Verified with `make helm-lint` and `helm template` (base + overlay): the two limit entries render at `1.2`.

## 2. Retire the implementation plan as a live status tracker (`docs`)

The phased build-out is finished, so the plan is history rather than a live tracker:

- Remove the **Implementation Status** table from the README (no longer front-and-center).
- Drop the per-PR **status-sync ritual** from `CLAUDE.md`.
- Reframe the `AGENTS.md` pointer so `IMPLEMENTATION_PLAN.md` reads as a historical record, with the Key Files table as the current reference.

`IMPLEMENTATION_PLAN.md` itself is kept as-is.