### PR TITLE
feat: emit identity-tuple label values as metric attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ballast.profiles` gauge for profile-count and by-business-unit dashboards.** A new observable gauge emits a value of `1` per `WorkloadProfile`, carrying that profile's identity-tuple label values as attributes plus a `state` attribute (`accruing` until the profile meets its threshold, then `ready`). Totals aggregate by count; grouping by a tuple attribute (e.g. `business_unit`) breaks the fleet down by that dimension. The gauge reads the controller cache at collection time, so it is always a fresh snapshot with no counter drift.
+
+- **Identity-tuple label values are now emitted as metric attributes.** Every profile-scoped metric (`samples.collected`, `fetch.errors`, `profiles.threshold_met`, `pods.processed`, `workload_profiles.created`/`purged`, `resize.applied`/`failed`/`skipped`, `webhook.mutations`) now carries one attribute per identity-tuple label. Each attribute key is the label's suffix (the segment after the last `/`) sanitized to `[a-z0-9_]` — e.g. `example.com/business-unit` becomes `business_unit` and `app.kubernetes.io/name` becomes `name`. If two labels would sanitize to the same suffix, the colliding ones fall back to their sanitized fully-qualified key so no attribute is dropped.
+
+### Fixed
+
+- **`ballast.samples.collected` was dead — it had no production caller and always read zero.** The counter is now incremented once per metric sample successfully written to the store (never on a write failure or in `--dry-run-measure`), carrying `source`, `resource`, `container`, and the profile's identity-tuple attributes.
+
+### Changed
+
+- **The `profile` attribute is now the readable profile name across all metrics.** `samples.collected` and `fetch.errors` previously carried the opaque tuple hash in place of a profile identifier; they now emit the same human-readable `profile` name as every other metric, alongside the identity-tuple attributes.
+
 ## [0.2.4] - 2026-07-01
 
 ### Added

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -332,6 +332,10 @@ func registerComponents(
 		return fmt.Errorf("set up resourceadjuster controller: %w", err)
 	}
 
+	if err := rec.RegisterProfileGauge(metricscollector.NewProfileLister(mgr.GetClient())); err != nil {
+		return fmt.Errorf("register profiles gauge: %w", err)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		return fmt.Errorf("set up health check: %w", err)
 	}

--- a/internal/controller/metricscollector/controller.go
+++ b/internal/controller/metricscollector/controller.go
@@ -137,10 +137,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	now := time.Now()
 	tupleHash := store.TupleHash(profile.Status.TupleLabels)
+	pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
 
 	excluded := r.excludedContainerNames(ctx, profile.Status.SelectorLabels)
 
-	observed, err := r.collectAllSamples(ctx, tupleHash, profile.Status.SelectorLabels, now, sources, excluded)
+	observed, err := r.collectAllSamples(ctx, tupleHash, pid, profile.Status.SelectorLabels, now, sources, excluded)
 	if err != nil { // coverage:ignore - Redis error
 		return ctrl.Result{}, err
 	}
@@ -157,7 +158,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	if allReady && !profile.Status.MeetsThreshold {
-		r.rec.ProfileThresholdMet(ctx, profile.Name, resolved.Name)
+		r.rec.ProfileThresholdMet(ctx, pid, resolved.Name)
 	}
 	base := profile.DeepCopy()
 	profile.Status.Containers = containerProfiles
@@ -183,6 +184,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) collectAllSamples(
 	ctx context.Context,
 	tupleHash string,
+	pid metrics.ProfileID,
 	selectorLabels map[string]string,
 	now time.Time,
 	sources map[string]*ballastv1.MetricsSource,
@@ -199,7 +201,7 @@ func (r *Reconciler) collectAllSamples(
 			continue
 		}
 
-		additional, err := r.collectFromSource(ctx, tupleHash, selectorLabels, now, sourceName, ms, p, excluded)
+		additional, err := r.collectFromSource(ctx, tupleHash, pid, selectorLabels, now, sourceName, ms, p, excluded)
 		if err != nil { // coverage:ignore - Redis error
 			return nil, err
 		}
@@ -223,6 +225,7 @@ func (r *Reconciler) collectAllSamples(
 func (r *Reconciler) collectFromSource(
 	ctx context.Context,
 	tupleHash string,
+	pid metrics.ProfileID,
 	selectorLabels map[string]string,
 	now time.Time,
 	sourceName string,
@@ -238,7 +241,7 @@ func (r *Reconciler) collectFromSource(
 		plugin.TimeWindow{End: now})
 	if err != nil {
 		log.Error(err, "FetchStats failed", "source", sourceName)
-		r.rec.FetchError(ctx, sourceName, tupleHash)
+		r.rec.FetchError(ctx, sourceName, pid)
 		return observed, nil
 	}
 
@@ -261,6 +264,7 @@ func (r *Reconciler) collectFromSource(
 		if err := r.writeSample(ctx, tupleHash, ms, s); err != nil { // coverage:ignore - Redis error
 			return nil, err
 		}
+		r.rec.SampleCollected(ctx, sourceName, s.Resource, s.ContainerName, pid)
 	}
 
 	return observed, nil

--- a/internal/controller/metricscollector/profilelister.go
+++ b/internal/controller/metricscollector/profilelister.go
@@ -1,0 +1,48 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package metricscollector
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/metrics"
+)
+
+// profileLister adapts a controller-runtime client into a metrics.ProfileLister,
+// letting the ballast.profiles gauge observe the current set of WorkloadProfiles
+// without pulling Kubernetes client dependencies into internal/metrics.
+type profileLister struct {
+	reader client.Reader
+}
+
+// NewProfileLister returns a metrics.ProfileLister backed by the given reader
+// (typically the manager cache).
+func NewProfileLister(c client.Reader) metrics.ProfileLister {
+	return &profileLister{reader: c}
+}
+
+// ListProfiles lists all WorkloadProfiles and maps each to a metrics.ProfileSnapshot
+// carrying its identity-tuple labels and readiness state.
+func (l *profileLister) ListProfiles(ctx context.Context) ([]metrics.ProfileSnapshot, error) {
+	var list ballastv1.WorkloadProfileList
+	if err := l.reader.List(ctx, &list); err != nil {
+		return nil, fmt.Errorf("listing WorkloadProfiles for profiles gauge: %w", err)
+	}
+	snaps := make([]metrics.ProfileSnapshot, 0, len(list.Items))
+	for i := range list.Items {
+		p := &list.Items[i]
+		snaps = append(snaps, metrics.ProfileSnapshot{
+			Labels: p.Status.TupleLabels,
+			Ready:  p.Status.MeetsThreshold,
+		})
+	}
+	return snaps, nil
+}

--- a/internal/controller/metricscollector/profilelister_test.go
+++ b/internal/controller/metricscollector/profilelister_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package metricscollector_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/controller/metricscollector"
+)
+
+func TestProfileLister_ListProfiles(t *testing.T) {
+	ready := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: "ready"}}
+	ready.Status.TupleLabels = map[string]string{"example.com/business-unit": "payments"}
+	ready.Status.MeetsThreshold = true
+
+	accruing := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: "accruing"}}
+	accruing.Status.TupleLabels = map[string]string{"example.com/business-unit": "search"}
+	accruing.Status.MeetsThreshold = false
+
+	fc := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithObjects(ready, accruing).
+		Build()
+
+	snaps, err := metricscollector.NewProfileLister(fc).ListProfiles(context.Background())
+	if err != nil {
+		t.Fatalf("ListProfiles: %v", err)
+	}
+	if len(snaps) != 2 {
+		t.Fatalf("snapshot count = %d, want 2", len(snaps))
+	}
+
+	byBU := make(map[string]bool) // business-unit -> Ready
+	for _, s := range snaps {
+		byBU[s.Labels["example.com/business-unit"]] = s.Ready
+	}
+	if !byBU["payments"] {
+		t.Errorf("payments profile Ready = false, want true")
+	}
+	if byBU["search"] {
+		t.Errorf("search profile Ready = true, want false")
+	}
+}
+
+func TestProfileLister_ListError(t *testing.T) {
+	boom := errors.New("list boom")
+	fc := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithInterceptorFuncs(interceptor.Funcs{
+			List: func(context.Context, client.WithWatch, client.ObjectList, ...client.ListOption) error {
+				return boom
+			},
+		}).
+		Build()
+
+	if _, err := metricscollector.NewProfileLister(fc).ListProfiles(context.Background()); !errors.Is(err, boom) {
+		t.Fatalf("ListProfiles error = %v, want wrapped %v", err, boom)
+	}
+}

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -91,16 +91,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, err // coverage:ignore - transient API error
 	}
 
+	pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
+
 	if r.ks.IsActive() {
 		log.Info("kill switch active, skipping resize",
 			"kill_switch", true, "kill_switch_reason", r.ks.Reason(), "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "kill_switch", profile.Name)
+		r.rec.ResizeSkipped(ctx, "kill_switch", pid)
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
 	if !profile.Status.MeetsThreshold {
 		log.V(1).Info("profile does not meet threshold, skipping resize", "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "not_ready", profile.Name)
+		r.rec.ResizeSkipped(ctx, "not_ready", pid)
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
@@ -110,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if resolved == nil {
 		log.Info("no policy matches profile, skipping resize", "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "no_policy", profile.Name)
+		r.rec.ResizeSkipped(ctx, "no_policy", pid)
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
@@ -164,10 +166,12 @@ func wantsResize(ann map[string]string) bool {
 func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile *ballastv1.WorkloadProfile, behaviors ballastv1.BehaviorConfig, interval time.Duration, policyName string) error {
 	log := ctrl.LoggerFrom(ctx)
 
+	pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
+
 	if last, ok := pod.Annotations[AnnotationLastResize]; ok {
 		if t, err := time.Parse(time.RFC3339, last); err == nil && time.Since(t) < interval {
 			log.V(1).Info("resize cooldown active, skipping", "pod", pod.Name, "namespace", pod.Namespace, "next_resize", t.Add(interval))
-			r.rec.ResizeSkipped(ctx, "cooldown", profile.Name)
+			r.rec.ResizeSkipped(ctx, "cooldown", pid)
 			return nil
 		}
 	}
@@ -175,7 +179,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 	recsByName := containerRecsByName(profile)
 	adjustments := computeAdjustments(pod, recsByName, behaviors)
 	if len(adjustments) == 0 {
-		r.rec.ResizeSkipped(ctx, "no_drift", profile.Name)
+		r.rec.ResizeSkipped(ctx, "no_drift", pid)
 		return nil
 	}
 
@@ -183,20 +187,20 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 
 	if r.dryRunResize {
 		log.Info("dry-run: would resize pod", append(logFields, "dry_run", true)...)
-		r.rec.ResizeSkipped(ctx, "dry_run", profile.Name)
+		r.rec.ResizeSkipped(ctx, "dry_run", pid)
 		return nil
 	}
 
 	if err := r.ResizePod(ctx, pod, adjustments); err != nil {
 		log.Error(err, "resize failed, marking pod blocked", logFields...)
-		r.rec.ResizeFailed(ctx, profile.Name, policyName, pod.Namespace)
+		r.rec.ResizeFailed(ctx, pid, policyName, pod.Namespace)
 		r.emitEvent(ctx, pod, corev1.EventTypeWarning, "ResizeBlocked",
 			fmt.Sprintf("in-place resize failed: %v", err))
 		return r.stampPodAnnotation(ctx, pod, AnnotationResizeBlocked, "true")
 	}
 
 	log.Info("resize applied", logFields...)
-	r.rec.ResizeApplied(ctx, profile.Name, policyName, pod.Namespace)
+	r.rec.ResizeApplied(ctx, pid, policyName, pod.Namespace)
 	r.emitEvent(ctx, pod, corev1.EventTypeNormal, "Resized", "in-place resize applied by Ballast")
 	return r.stampPodAnnotation(ctx, pod, AnnotationLastResize, metav1.Now().UTC().Format(time.RFC3339))
 }

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -146,6 +146,8 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		return ctrl.Result{}, err
 	}
 
+	pid := metrics.ProfileID{Name: profName, Labels: tupleLabels}
+
 	// Add finalizer before stamping the annotation so delete is always handled
 	// even if the annotation stamp fails.
 	if !controllerutil.ContainsFinalizer(pod, FinalizerName) {
@@ -154,7 +156,7 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		if err := r.client.Patch(ctx, pod, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
 			return ctrl.Result{}, err
 		}
-		r.rec.PodProcessed(ctx, "created", pod.Namespace, profName)
+		r.rec.PodProcessed(ctx, "created", pod.Namespace, pid)
 	}
 
 	if err := r.stampProfileRef(ctx, pod, profName); err != nil { // coverage:ignore - transient API error
@@ -178,7 +180,15 @@ func (r *PodReconciler) handleDelete(ctx context.Context, pod *corev1.Pod) (ctrl
 		if err := r.setActiveWorkloads(ctx, profName); err != nil { // coverage:ignore - transient API error
 			return ctrl.Result{}, err
 		}
-		r.rec.PodProcessed(ctx, "deleted", pod.Namespace, profName)
+		// Recover the identity-tuple labels from the profile so the "deleted" event
+		// carries the same attributes as "created"; fall back to name-only if the
+		// profile has already been purged.
+		pid := metrics.ProfileID{Name: profName}
+		var profile ballastv1.WorkloadProfile
+		if err := r.client.Get(ctx, types.NamespacedName{Name: profName}, &profile); err == nil {
+			pid.Labels = profile.Status.TupleLabels
+		}
+		r.rec.PodProcessed(ctx, "deleted", pod.Namespace, pid)
 	}
 
 	base := pod.DeepCopy()
@@ -205,7 +215,7 @@ func (r *PodReconciler) ensureProfile(ctx context.Context, profName string, tupl
 		}
 		return err // coverage:ignore - transient non-AlreadyExists error
 	}
-	r.rec.WorkloadProfileCreated(ctx, profName)
+	r.rec.WorkloadProfileCreated(ctx, metrics.ProfileID{Name: profName, Labels: tupleLabels})
 
 	// Status is a subresource; must be updated after creation.
 	profile.Status.TupleLabels = tupleLabels
@@ -345,7 +355,7 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	if err := r.client.Delete(ctx, &profile); err != nil { // coverage:ignore - transient API error
 		return ctrl.Result{}, err
 	}
-	r.rec.WorkloadProfilePurged(ctx, profile.Name)
+	r.rec.WorkloadProfilePurged(ctx, metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels})
 	return ctrl.Result{}, nil
 }
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -67,33 +67,111 @@ func gatherGauge(t *testing.T, reg *promclient.Registry, name string) float64 {
 	return 0
 }
 
+// labelSet is a name->value map of one metric sample's labels.
+type labelSet map[string]string
+
+// gatherSeries returns every sample of the named metric as (labels, value) pairs.
+// It reads counter or gauge values, whichever is populated.
+func gatherSeries(t *testing.T, reg *promclient.Registry, name string) []struct {
+	labels labelSet
+	value  float64
+} {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	var out []struct {
+		labels labelSet
+		value  float64
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			ls := make(labelSet, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				ls[lp.GetName()] = lp.GetValue()
+			}
+			val := m.GetCounter().GetValue()
+			if m.GetGauge() != nil {
+				val = m.GetGauge().GetValue()
+			}
+			out = append(out, struct {
+				labels labelSet
+				value  float64
+			}{labels: ls, value: val})
+		}
+	}
+	return out
+}
+
+// firstLabels returns the label set of the first sample of the named metric.
+func firstLabels(t *testing.T, reg *promclient.Registry, name string) labelSet {
+	t.Helper()
+	series := gatherSeries(t, reg, name)
+	if len(series) == 0 {
+		t.Fatalf("no series found for metric %q", name)
+	}
+	return series[0].labels
+}
+
+// biz is an identity-tuple label map used across attribute-mapping tests.
+func bizLabels() map[string]string {
+	return map[string]string{
+		"example.com/business-unit": "payments",
+		"app.kubernetes.io/name":    "web",
+	}
+}
+
 func TestRecorder_NilSafe(t *testing.T) {
 	var rec *metrics.Recorder
 	ctx := context.Background()
-	rec.SampleCollected(ctx, "src", "cpu", "app", "hash")
-	rec.FetchError(ctx, "src", "hash")
-	rec.ProfileThresholdMet(ctx, "prof", "policy")
-	rec.PodProcessed(ctx, "created", "default", "prof")
-	rec.WorkloadProfileCreated(ctx, "prof")
-	rec.WorkloadProfilePurged(ctx, "prof")
-	rec.ResizeApplied(ctx, "prof", "policy", "default")
-	rec.ResizeFailed(ctx, "prof", "policy", "default")
-	rec.ResizeSkipped(ctx, "cooldown", "prof")
-	rec.WebhookMutation(ctx, "mutated", "default", "prof")
+	id := metrics.ProfileID{Name: "prof", Labels: map[string]string{"app.kubernetes.io/name": "web"}}
+	rec.SampleCollected(ctx, "src", "cpu", "app", id)
+	rec.FetchError(ctx, "src", id)
+	rec.ProfileThresholdMet(ctx, id, "policy")
+	rec.PodProcessed(ctx, "created", "default", id)
+	rec.WorkloadProfileCreated(ctx, id)
+	rec.WorkloadProfilePurged(ctx, id)
+	rec.ResizeApplied(ctx, id, "policy", "default")
+	rec.ResizeFailed(ctx, id, "policy", "default")
+	rec.ResizeSkipped(ctx, "cooldown", id)
+	rec.WebhookMutation(ctx, "mutated", "default", id)
 	rec.KillSwitchTransition(ctx, "activated")
 	rec.SetKillSwitchActive(true, "test")
+	if err := rec.RegisterProfileGauge(nil); err != nil {
+		t.Errorf("RegisterProfileGauge on nil recorder = %v, want nil", err)
+	}
 }
 
 func TestRecorder_SampleCollected(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.SampleCollected(ctx, "k8s", "cpu", "app", "abc123")
-	rec.SampleCollected(ctx, "k8s", "cpu", "app", "abc123")
+	id := metrics.ProfileID{Name: "payments--web", Labels: bizLabels()}
+	rec.SampleCollected(ctx, "k8s", "cpu", "app", id)
+	rec.SampleCollected(ctx, "k8s", "cpu", "app", id)
 
 	got := gatherCounter(t, reg, "ballast_samples_collected_total")
 	if got != 2 {
 		t.Errorf("ballast_samples_collected_total = %v, want 2", got)
+	}
+
+	// samples.collected now carries the readable profile name and tuple attributes.
+	ls := firstLabels(t, reg, "ballast_samples_collected_total")
+	if ls["profile"] != "payments--web" {
+		t.Errorf("profile attr = %q, want payments--web", ls["profile"])
+	}
+	if ls["business_unit"] != "payments" {
+		t.Errorf("business_unit attr = %q, want payments", ls["business_unit"])
+	}
+	if ls["name"] != "web" {
+		t.Errorf("name attr = %q, want web", ls["name"])
+	}
+	if ls["source"] != "k8s" || ls["resource"] != "cpu" || ls["container"] != "app" {
+		t.Errorf("source/resource/container attrs = %q/%q/%q", ls["source"], ls["resource"], ls["container"])
 	}
 }
 
@@ -101,11 +179,23 @@ func TestRecorder_FetchError(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.FetchError(ctx, "k8s", "abc123")
+	rec.FetchError(ctx, "k8s", metrics.ProfileID{Name: "payments--web", Labels: bizLabels()})
 
 	got := gatherCounter(t, reg, "ballast_fetch_errors_total")
 	if got != 1 {
 		t.Errorf("ballast_fetch_errors_total = %v, want 1", got)
+	}
+
+	// fetch.errors now carries the readable profile name and tuple attributes.
+	ls := firstLabels(t, reg, "ballast_fetch_errors_total")
+	if ls["profile"] != "payments--web" {
+		t.Errorf("profile attr = %q, want payments--web", ls["profile"])
+	}
+	if ls["business_unit"] != "payments" || ls["name"] != "web" {
+		t.Errorf("tuple attrs = business_unit:%q name:%q", ls["business_unit"], ls["name"])
+	}
+	if ls["source"] != "k8s" {
+		t.Errorf("source attr = %q, want k8s", ls["source"])
 	}
 }
 
@@ -113,7 +203,7 @@ func TestRecorder_ProfileThresholdMet(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.ProfileThresholdMet(ctx, "frontend--web", "default")
+	rec.ProfileThresholdMet(ctx, metrics.ProfileID{Name: "frontend--web"}, "default")
 
 	got := gatherCounter(t, reg, "ballast_profiles_threshold_met_total")
 	if got != 1 {
@@ -125,7 +215,7 @@ func TestRecorder_PodProcessed(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.PodProcessed(ctx, "created", "default", "frontend--web")
+	rec.PodProcessed(ctx, "created", "default", metrics.ProfileID{Name: "frontend--web"})
 
 	got := gatherCounter(t, reg, "ballast_pods_processed_total")
 	if got != 1 {
@@ -137,7 +227,7 @@ func TestRecorder_WorkloadProfileCreated(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.WorkloadProfileCreated(ctx, "frontend--web")
+	rec.WorkloadProfileCreated(ctx, metrics.ProfileID{Name: "frontend--web"})
 
 	got := gatherCounter(t, reg, "ballast_workload_profiles_created_total")
 	if got != 1 {
@@ -149,7 +239,7 @@ func TestRecorder_WorkloadProfilePurged(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.WorkloadProfilePurged(ctx, "frontend--web")
+	rec.WorkloadProfilePurged(ctx, metrics.ProfileID{Name: "frontend--web"})
 
 	got := gatherCounter(t, reg, "ballast_workload_profiles_purged_total")
 	if got != 1 {
@@ -161,7 +251,7 @@ func TestRecorder_ResizeApplied(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.ResizeApplied(ctx, "frontend--web", "default", "staging")
+	rec.ResizeApplied(ctx, metrics.ProfileID{Name: "frontend--web"}, "default", "staging")
 
 	got := gatherCounter(t, reg, "ballast_resize_applied_total")
 	if got != 1 {
@@ -173,7 +263,7 @@ func TestRecorder_ResizeFailed(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.ResizeFailed(ctx, "frontend--web", "default", "staging")
+	rec.ResizeFailed(ctx, metrics.ProfileID{Name: "frontend--web"}, "default", "staging")
 
 	got := gatherCounter(t, reg, "ballast_resize_failed_total")
 	if got != 1 {
@@ -185,7 +275,7 @@ func TestRecorder_ResizeSkipped(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.ResizeSkipped(ctx, "cooldown", "frontend--web")
+	rec.ResizeSkipped(ctx, "cooldown", metrics.ProfileID{Name: "frontend--web"})
 
 	got := gatherCounter(t, reg, "ballast_resize_skipped_total")
 	if got != 1 {
@@ -197,7 +287,7 @@ func TestRecorder_WebhookMutation(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.WebhookMutation(ctx, "mutated", "default", "frontend--web")
+	rec.WebhookMutation(ctx, "mutated", "default", metrics.ProfileID{Name: "frontend--web"})
 
 	got := gatherCounter(t, reg, "ballast_webhook_mutations_total")
 	if got != 1 {
@@ -245,7 +335,7 @@ func TestSetupProvider_NoOp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRecorder: %v", err)
 	}
-	rec.SampleCollected(ctx, "k8s", "cpu", "app", "hash")
+	rec.SampleCollected(ctx, "k8s", "cpu", "app", metrics.ProfileID{Name: "prof"})
 }
 
 // shortCtx returns a context that times out quickly, for use in shutdown calls
@@ -270,7 +360,7 @@ func TestSetupProvider_OTLPGrpc(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRecorder: %v", err)
 	}
-	rec.SampleCollected(ctx, "k8s", "cpu", "app", "hash")
+	rec.SampleCollected(ctx, "k8s", "cpu", "app", metrics.ProfileID{Name: "prof"})
 }
 
 func TestSetupProvider_OTLPDefaultInterval(t *testing.T) {
@@ -342,7 +432,7 @@ func TestSetupProvider_Prometheus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewRecorder: %v", err)
 	}
-	rec.SampleCollected(ctx, "k8s", "cpu", "app", "hash")
+	rec.SampleCollected(ctx, "k8s", "cpu", "app", metrics.ProfileID{Name: "prof"})
 
 	mfs, err := reg.Gather()
 	if err != nil {
@@ -358,3 +448,142 @@ func TestSetupProvider_Prometheus(t *testing.T) {
 		t.Error("ballast_samples_collected_total not found after SetupProvider with Prometheus")
 	}
 }
+
+// TestRecorder_TupleAttrs_SuffixCollision asserts that when two identity-tuple labels
+// share a suffix (the segment after the last '/'), both fall back to their sanitized
+// fully-qualified key so neither attribute is dropped.
+func TestRecorder_TupleAttrs_SuffixCollision(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+	ctx := context.Background()
+
+	id := metrics.ProfileID{
+		Name: "collide",
+		Labels: map[string]string{
+			"a.example.com/x": "one",
+			"b.example.com/x": "two",
+		},
+	}
+	rec.WorkloadProfileCreated(ctx, id)
+
+	ls := firstLabels(t, reg, "ballast_workload_profiles_created_total")
+	// Suffix "x" collides, so both keys sanitize to their full form.
+	if ls["a_example_com_x"] != "one" {
+		t.Errorf("a_example_com_x attr = %q, want one", ls["a_example_com_x"])
+	}
+	if ls["b_example_com_x"] != "two" {
+		t.Errorf("b_example_com_x attr = %q, want two", ls["b_example_com_x"])
+	}
+	// The bare suffix must NOT be present (it would be ambiguous).
+	if _, ok := ls["x"]; ok {
+		t.Errorf("bare suffix attr %q should not be present on collision", "x")
+	}
+}
+
+// TestRecorder_TupleAttrs_NoSlashKey asserts a label key with no '/' is used whole
+// as the attribute key (after sanitization).
+func TestRecorder_TupleAttrs_NoSlashKey(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+	ctx := context.Background()
+
+	id := metrics.ProfileID{Name: "noslash", Labels: map[string]string{"team": "core"}}
+	rec.WorkloadProfileCreated(ctx, id)
+
+	ls := firstLabels(t, reg, "ballast_workload_profiles_created_total")
+	if ls["team"] != "core" {
+		t.Errorf("team attr = %q, want core", ls["team"])
+	}
+}
+
+// TestRecorder_ZeroProfileID asserts a zero ProfileID contributes no profile or
+// tuple attributes, only the metric's own attributes.
+func TestRecorder_ZeroProfileID(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+	ctx := context.Background()
+
+	rec.WebhookMutation(ctx, "kill_switch", "default", metrics.ProfileID{})
+
+	ls := firstLabels(t, reg, "ballast_webhook_mutations_total")
+	if _, ok := ls["profile"]; ok {
+		t.Errorf("profile attr present on zero ProfileID: %q", ls["profile"])
+	}
+	if ls["result"] != "kill_switch" || ls["namespace"] != "default" {
+		t.Errorf("result/namespace attrs = %q/%q", ls["result"], ls["namespace"])
+	}
+	// Only the OTel-required target_info/scope labels plus result+namespace should exist;
+	// no suffix-derived tuple attribute keys.
+	for _, forbidden := range []string{"business_unit", "name", "x"} {
+		if _, ok := ls[forbidden]; ok {
+			t.Errorf("unexpected tuple attr %q on zero ProfileID", forbidden)
+		}
+	}
+}
+
+// fakeLister is a test double for metrics.ProfileLister.
+type fakeLister struct {
+	snaps []metrics.ProfileSnapshot
+	err   error
+}
+
+func (f fakeLister) ListProfiles(_ context.Context) ([]metrics.ProfileSnapshot, error) {
+	return f.snaps, f.err
+}
+
+func TestRecorder_RegisterProfileGauge(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+
+	lister := fakeLister{snaps: []metrics.ProfileSnapshot{
+		{Labels: map[string]string{"example.com/business-unit": "payments"}, Ready: true},
+		{Labels: map[string]string{"example.com/business-unit": "search"}, Ready: false},
+	}}
+	if err := rec.RegisterProfileGauge(lister); err != nil {
+		t.Fatalf("RegisterProfileGauge: %v", err)
+	}
+
+	series := gatherSeries(t, reg, "ballast_profiles")
+	if len(series) != 2 {
+		t.Fatalf("ballast_profiles series count = %d, want 2", len(series))
+	}
+
+	byState := make(map[string]labelSet)
+	for _, s := range series {
+		if s.value != 1 {
+			t.Errorf("ballast_profiles value = %v, want 1 (state=%q)", s.value, s.labels["state"])
+		}
+		byState[s.labels["state"]] = s.labels
+	}
+
+	ready, ok := byState["ready"]
+	if !ok {
+		t.Fatal("no ballast_profiles series with state=ready")
+	}
+	if ready["business_unit"] != "payments" {
+		t.Errorf("ready business_unit = %q, want payments", ready["business_unit"])
+	}
+
+	accruing, ok := byState["accruing"]
+	if !ok {
+		t.Fatal("no ballast_profiles series with state=accruing")
+	}
+	if accruing["business_unit"] != "search" {
+		t.Errorf("accruing business_unit = %q, want search", accruing["business_unit"])
+	}
+}
+
+func TestRecorder_RegisterProfileGauge_ListerError(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+
+	if err := rec.RegisterProfileGauge(fakeLister{err: errListerBoom}); err != nil {
+		t.Fatalf("RegisterProfileGauge: %v", err)
+	}
+
+	// Gather triggers the callback; the lister error propagates so no series is emitted.
+	if got := gatherGauge(t, reg, "ballast_profiles"); got != 0 {
+		t.Errorf("ballast_profiles = %v after lister error, want 0 (no series)", got)
+	}
+}
+
+var errListerBoom = errBoom("lister boom")
+
+type errBoom string
+
+func (e errBoom) Error() string { return string(e) }

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -8,15 +8,40 @@ package metrics
 
 import (
 	"context"
+	"strings"
 	"sync/atomic"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
+// ProfileID identifies the WorkloadProfile a metric is about. Name is the readable
+// profile name; Labels is the identity-tuple label map (the same keys configured in
+// ballastConfig.identityLabels). Both are optional: a zero ProfileID (e.g. for a
+// webhook call that never resolved a profile) contributes no profile attributes.
+type ProfileID struct {
+	Name   string
+	Labels map[string]string
+}
+
+// ProfileSnapshot is the per-profile state the profiles gauge observes.
+type ProfileSnapshot struct {
+	Labels map[string]string
+	Ready  bool
+}
+
+// ProfileLister supplies the current set of WorkloadProfiles to the profiles gauge
+// callback. It is implemented outside this package (against the controller cache) so
+// internal/metrics stays free of Kubernetes client dependencies.
+type ProfileLister interface {
+	ListProfiles(ctx context.Context) ([]ProfileSnapshot, error)
+}
+
 // Recorder holds all Ballast OTel instruments. All methods are nil-safe: calling
 // any method on a nil *Recorder is a no-op, allowing callers to pass nil in tests.
 type Recorder struct {
+	meter metric.Meter
+
 	samplesCollected        metric.Int64Counter
 	fetchErrors             metric.Int64Counter
 	profileThresholdMet     metric.Int64Counter
@@ -37,7 +62,7 @@ type Recorder struct {
 // if any instrument registration fails.
 func NewRecorder(provider metric.MeterProvider) (*Recorder, error) {
 	m := provider.Meter("ballast")
-	r := &Recorder{}
+	r := &Recorder{meter: m}
 	r.ksReason.Store("")
 
 	var err error
@@ -100,121 +125,193 @@ func NewRecorder(provider metric.MeterProvider) (*Recorder, error) {
 	return r, nil
 }
 
+// RegisterProfileGauge registers the ballast.profiles observable gauge, which emits a
+// value of 1 per WorkloadProfile carrying its identity-tuple attributes plus a state
+// attribute ("accruing" until the profile meets its threshold, then "ready"). Dashboards
+// aggregate it: total = count, by business unit = count grouped by that attribute, etc.
+// The lister reads from the controller cache at collection time, so the gauge is always
+// a fresh snapshot with no counters to drift. Nil-safe; call once during setup.
+func (r *Recorder) RegisterProfileGauge(lister ProfileLister) error {
+	if r == nil {
+		return nil
+	}
+	gauge, err := r.meter.Int64ObservableGauge("ballast.profiles",
+		metric.WithDescription("WorkloadProfiles by identity tuple and readiness state (1 per profile)"),
+	)
+	if err != nil { // coverage:ignore - OTel SDK never errors for valid instrument registration
+		return err
+	}
+	_, err = r.meter.RegisterCallback(func(ctx context.Context, o metric.Observer) error {
+		snaps, lerr := lister.ListProfiles(ctx)
+		if lerr != nil {
+			return lerr
+		}
+		for _, s := range snaps {
+			state := "accruing"
+			if s.Ready {
+				state = "ready"
+			}
+			attrs := append(profileAttrs(ProfileID{Labels: s.Labels}), attribute.String("state", state))
+			o.ObserveInt64(gauge, 1, metric.WithAttributes(attrs...))
+		}
+		return nil
+	}, gauge)
+	return err
+}
+
+// profileAttrs converts a ProfileID into OTel attributes: the readable profile name
+// (when set) plus one attribute per identity-tuple label. Each label's attribute key is
+// the segment after the last '/', sanitized to [a-z0-9_]; if two labels would sanitize to
+// the same key, the colliding ones fall back to their sanitized fully-qualified key.
+func profileAttrs(id ProfileID) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, len(id.Labels)+1)
+	if id.Name != "" {
+		attrs = append(attrs, attribute.String("profile", id.Name))
+	}
+	// Count sanitized suffixes so colliding keys can fall back to the full key.
+	counts := make(map[string]int, len(id.Labels))
+	for k := range id.Labels {
+		counts[sanitizeAttrKey(labelSuffix(k))]++
+	}
+	for k, v := range id.Labels {
+		name := sanitizeAttrKey(labelSuffix(k))
+		if counts[name] > 1 {
+			name = sanitizeAttrKey(k)
+		}
+		attrs = append(attrs, attribute.String(name, v))
+	}
+	return attrs
+}
+
+// labelSuffix returns the portion of a label key after the last '/', or the whole key
+// when there is no '/'.
+func labelSuffix(key string) string {
+	if i := strings.LastIndex(key, "/"); i >= 0 {
+		return key[i+1:]
+	}
+	return key
+}
+
+// sanitizeAttrKey lowercases s and replaces every character outside [a-z0-9_] with '_'.
+func sanitizeAttrKey(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
 // SampleCollected records one metric sample written to the store.
-func (r *Recorder) SampleCollected(ctx context.Context, source, resource, container, tupleHash string) {
+func (r *Recorder) SampleCollected(ctx context.Context, source, resource, container string, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.samplesCollected.Add(ctx, 1, metric.WithAttributes(
+	attrs := append(profileAttrs(id),
 		attribute.String("source", source),
 		attribute.String("resource", resource),
 		attribute.String("container", container),
-		attribute.String("profile", tupleHash),
-	))
+	)
+	r.samplesCollected.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // FetchError records a FetchStats failure for a metrics source.
-func (r *Recorder) FetchError(ctx context.Context, source, tupleHash string) {
+func (r *Recorder) FetchError(ctx context.Context, source string, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.fetchErrors.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("source", source),
-		attribute.String("profile", tupleHash),
-	))
+	attrs := append(profileAttrs(id), attribute.String("source", source))
+	r.fetchErrors.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // ProfileThresholdMet records when a WorkloadProfile transitions to meets-threshold.
-func (r *Recorder) ProfileThresholdMet(ctx context.Context, profile, policy string) {
+func (r *Recorder) ProfileThresholdMet(ctx context.Context, id ProfileID, policy string) {
 	if r == nil {
 		return
 	}
-	r.profileThresholdMet.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("profile", profile),
-		attribute.String("policy", policy),
-	))
+	attrs := append(profileAttrs(id), attribute.String("policy", policy))
+	r.profileThresholdMet.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // PodProcessed records a pod being processed by the workload watcher.
 // event is "created" or "deleted".
-func (r *Recorder) PodProcessed(ctx context.Context, event, namespace, profile string) {
+func (r *Recorder) PodProcessed(ctx context.Context, event, namespace string, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.podsProcessed.Add(ctx, 1, metric.WithAttributes(
+	attrs := append(profileAttrs(id),
 		attribute.String("event", event),
 		attribute.String("namespace", namespace),
-		attribute.String("profile", profile),
-	))
+	)
+	r.podsProcessed.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // WorkloadProfileCreated records a new WorkloadProfile being created.
-func (r *Recorder) WorkloadProfileCreated(ctx context.Context, profile string) {
+func (r *Recorder) WorkloadProfileCreated(ctx context.Context, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.workloadProfilesCreated.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("profile", profile),
-	))
+	r.workloadProfilesCreated.Add(ctx, 1, metric.WithAttributes(profileAttrs(id)...))
 }
 
 // WorkloadProfilePurged records a WorkloadProfile being deleted after orphan TTL.
-func (r *Recorder) WorkloadProfilePurged(ctx context.Context, profile string) {
+func (r *Recorder) WorkloadProfilePurged(ctx context.Context, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.workloadProfilesPurged.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("profile", profile),
-	))
+	r.workloadProfilesPurged.Add(ctx, 1, metric.WithAttributes(profileAttrs(id)...))
 }
 
 // ResizeApplied records a successful in-place resize.
-func (r *Recorder) ResizeApplied(ctx context.Context, profile, policy, namespace string) {
+func (r *Recorder) ResizeApplied(ctx context.Context, id ProfileID, policy, namespace string) {
 	if r == nil {
 		return
 	}
-	r.resizeApplied.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("profile", profile),
+	attrs := append(profileAttrs(id),
 		attribute.String("policy", policy),
 		attribute.String("namespace", namespace),
-	))
+	)
+	r.resizeApplied.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // ResizeFailed records a failed in-place resize.
-func (r *Recorder) ResizeFailed(ctx context.Context, profile, policy, namespace string) {
+func (r *Recorder) ResizeFailed(ctx context.Context, id ProfileID, policy, namespace string) {
 	if r == nil {
 		return
 	}
-	r.resizeFailed.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("profile", profile),
+	attrs := append(profileAttrs(id),
 		attribute.String("policy", policy),
 		attribute.String("namespace", namespace),
-	))
+	)
+	r.resizeFailed.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // ResizeSkipped records a resize evaluation that was skipped without issuing a patch.
 // reason is one of: cooldown, no_drift, kill_switch, not_ready, no_policy, dry_run.
-func (r *Recorder) ResizeSkipped(ctx context.Context, reason, profile string) {
+func (r *Recorder) ResizeSkipped(ctx context.Context, reason string, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.resizeSkipped.Add(ctx, 1, metric.WithAttributes(
-		attribute.String("reason", reason),
-		attribute.String("profile", profile),
-	))
+	attrs := append(profileAttrs(id), attribute.String("reason", reason))
+	r.resizeSkipped.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // WebhookMutation records a pod admission webhook invocation.
 // result is one of: kill_switch, skipped, not_available, dry_run, mutated.
-func (r *Recorder) WebhookMutation(ctx context.Context, result, namespace, profile string) {
+func (r *Recorder) WebhookMutation(ctx context.Context, result, namespace string, id ProfileID) {
 	if r == nil {
 		return
 	}
-	r.webhookMutations.Add(ctx, 1, metric.WithAttributes(
+	attrs := append(profileAttrs(id),
 		attribute.String("result", result),
 		attribute.String("namespace", namespace),
-		attribute.String("profile", profile),
-	))
+	)
+	r.webhookMutations.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // KillSwitchTransition records a kill switch state change.

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -62,7 +62,7 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 
 	if m.ks.IsActive() {
 		log.Info("kill switch active, skipping mutation", "reason", m.ks.Reason())
-		m.rec.WebhookMutation(ctx, "kill_switch", req.Namespace, "")
+		m.rec.WebhookMutation(ctx, "kill_switch", req.Namespace, metrics.ProfileID{})
 		return admission.Allowed("kill switch active")
 	}
 
@@ -78,11 +78,11 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 	profile, ok, err := m.resolveApplyProfile(ctx, &pod)
 	if err != nil {
 		log.V(1).Info("profile resolution error, allowing without mutation", "err", err)
-		m.rec.WebhookMutation(ctx, "not_available", req.Namespace, "")
+		m.rec.WebhookMutation(ctx, "not_available", req.Namespace, metrics.ProfileID{})
 		return admission.Allowed("profile not available")
 	}
 	if !ok {
-		m.rec.WebhookMutation(ctx, "skipped", req.Namespace, "")
+		m.rec.WebhookMutation(ctx, "skipped", req.Namespace, metrics.ProfileID{})
 		return admission.Allowed("apply not active or profile not ready")
 	}
 
@@ -129,12 +129,14 @@ func (m *PodMutator) mutate(ctx context.Context, pod *corev1.Pod, profile *balla
 	applied := applyRecommendations(modifiedPod, profile)
 	log.Info("applying resource recommendations", "dry_run", m.dryRunApply, "containers", applied)
 
+	pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
+
 	if m.dryRunApply {
-		m.rec.WebhookMutation(ctx, "dry_run", pod.Namespace, profile.Name)
+		m.rec.WebhookMutation(ctx, "dry_run", pod.Namespace, pid)
 		return admission.Allowed("dry-run: apply suppressed")
 	}
 
-	m.rec.WebhookMutation(ctx, "mutated", pod.Namespace, profile.Name)
+	m.rec.WebhookMutation(ctx, "mutated", pod.Namespace, pid)
 	return patchResponse(pod, modifiedPod)
 }
 


### PR DESCRIPTION
## What

Profile-scoped metrics now carry one attribute **per identity-tuple label**, so dashboards can group and filter by the same dimensions that define a profile (name, component, and whatever else an install configures in `ballastConfig.identityLabels`) without parsing the concatenated profile name.

- **Tuple-label attributes.** Each label becomes an attribute keyed by its sanitized suffix (the segment after the last `/`, lowercased to `[a-z0-9_]`), e.g. `app.kubernetes.io/name` → `name`. If two labels would sanitize to the same key, the colliding ones fall back to their sanitized fully-qualified key so nothing is dropped. This reuses `identityLabels`; no new config, and cardinality stays bounded (the tuple is the grouping key).
- **`profile` attribute reconciled** to the readable profile name across every metric. It was the tuple *hash* on `ballast.samples.collected` and `ballast.fetch.errors`, so a `profile` selector didn't line up across panels.
- **`ballast.samples.collected` is now actually incremented.** It had no caller — the instrument was registered but dead — so it never emitted. Wired into the sample-write path (counted only on a successful write).
- **New `ballast.profiles` observable gauge:** value 1 per WorkloadProfile, carrying the tuple attributes plus `state` (`accruing` until the profile meets its threshold, then `ready`). Backed by a lister that reads the controller cache at collection time (no counters to drift). Powers profile-count / accruing-vs-ready / group-by-dimension panels.
- **`deleted` pod event** now recovers the tuple labels from the profile so it matches the `created` event (name-only fallback if the profile was already purged).

`ProfileID{Name, Labels}` replaces the bare profile/hash string across the recorder API and all call sites.

## Verification

- Coverage gate green (`make test-coverage-check`).
- Changed packages lint clean (`golangci-lint run ./internal/... ./cmd/...` → 0 issues).