### PR TITLE
feat: level-triggered enrollment and finalizer-based profile history cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,10 @@
 
 > This file is the primary entry point for AI agents working on ballast.
 > Read DESIGN.md for full system context before making changes.
+> **For any change to enrollment or WorkloadProfile lifecycle, read
+> [docs/convergence.md](docs/convergence.md) first** — it is the canonical
+> convergence contract (sequence diagrams + invariants) and must be updated
+> alongside such changes.
 > The Key Files table below is the current reference. IMPLEMENTATION_PLAN.md is a
 > historical record of the phased build-out, not a live status tracker.
 
@@ -114,10 +118,20 @@ Not a workload reconciler — it watches the `ballast-kill-switch` ConfigMap (in
 
 ### WorkloadWatcher (`internal/controller/workloadwatcher/`)
 
+> **Before changing enrollment or profile-lifecycle behavior, read
+> [docs/convergence.md](docs/convergence.md)** — it holds the canonical sequence
+> diagrams and design invariants for how convergence is achieved. Keep it in sync
+> with any change here.
+
+Enrollment is **level-triggered**: every pod CREATE/UPDATE reconcile recomputes the
+desired profile from the pod's current labels and the current `identityLabels` and
+reconciles toward it. The `profile-ref` stamp is a hint (a deterministic function of
+identity), not the source of truth; it is trusted verbatim only on the DELETE path.
+
 Two reconcilers share the package:
 
-- `PodReconciler` — watches pods carrying any Ballast behavior annotation. On CREATE: reads `BallastConfig.identityLabels`, extracts the identity tuple, creates `WorkloadProfile` if absent, increments `activeWorkloads`, stamps `profile-ref` annotation on the pod. On DELETE: decrements `activeWorkloads`; sets `Orphaned` condition when it reaches zero. Kill switch suppresses CREATE path only; DELETE path always runs so accounting stays correct.
-- `ProfileReconciler` — watches `WorkloadProfile` objects. Checks orphan TTL; if exceeded, purges Redis keys via `AllKeysForHash`/`DeleteKey` and deletes the profile.
+- `PodReconciler` — watches pods carrying any Ballast behavior annotation (also watches WorkloadProfile deletions and BallastConfig `identityLabels` changes to converge promptly). On CREATE/UPDATE: if enrolled, computes the target profile, creates the `WorkloadProfile` if absent (recreating it if deleted), stamps `profile-ref`, and recomputes `activeWorkloads` from live pods. If the computed name differs from the stamp → **migrate** (re-stamp, recount new and old). If no behavior annotation remains → **un-enroll** (remove `profile-ref` + finalizer, decrement old). On DELETE: reads the stamp (no recompute), recounts, sets `Orphaned` at zero. Kill switch suppresses the CREATE path only; DELETE/decrement always runs. Counts are recomputed from live pods (never `++/--`), so they self-heal.
+- `ProfileReconciler` — watches `WorkloadProfile` objects. Owns the cleanup finalizer (`ballast.tightlinesoftware.com/profile-cleanup`): on any deletion it purges Redis keys via `AllKeysForHash`/`DeleteKey` before releasing the object, so manual `kubectl delete` clears history just like the orphan-TTL sweep. Orphan-TTL expiry issues the `Delete`; the finalizer does the purge.
 
 Exported helpers used by the webhook: `ExtractTupleLabels(podLabels, identityLabels)` and `ProfileName(tupleLabels, identityLabels)`. `ProfileName` joins label values in `identityLabels` order (not alphabetically) so the name reads naturally, e.g., `nginx--nocomponent` when `identityLabels = ["name", "component"]`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ warrants a 0.3.0 minor release.
 
   Behavior note: deleting a `WorkloadProfile` that still has matching live pods is now a **history reset, not a permanent removal** — the profile regenerates (empty) while matching pods exist. To permanently remove a profile, remove the workload's Ballast annotations (or delete its pods) first, then delete the profile.
 
+### Fixed
+
+- **Stale `activeWorkloads` counts now self-heal.** The profile reconciler independently recomputes each profile's count from live pod state on every profile event and informer resync, writing only on change. Previously a profile whose last referencing pod migrated away, un-enrolled, or disappeared without a processed delete event could keep a stale non-zero count forever, never orphan, and never age out (leaking the profile and its Redis history).
+
+- **Profile identity labels in status now converge.** `status.tupleLabels` and `status.selectorLabels` are patched whenever they differ from the values recomputed on a member pod's reconcile, and the write is a conflict-free patch. Previously they were written exactly once at profile creation; if that write was lost (for example to a conflict with the cleanup-finalizer back-fill), the profile was never measured and its eventual Redis purge targeted the wrong key hash.
+
+- **Kill-switch releases now converge within a minute.** Pod reconciles skipped while the kill switch is active requeue every minute instead of waiting for the informer resync, so enrollment work deferred during an outage (including an `identityLabels` fan-out) resumes promptly once the switch is released.
+
+- **BallastConfig re-creation is a prompt convergence trigger.** The config watch now admits create events (filtered to the canonical BallastConfig name), so deleting and re-applying the config with different `identityLabels` migrates pods promptly instead of waiting for resync. A pod arriving while its profile is mid-deletion server-side (create returns AlreadyExists through a stale cache) now requeues instead of binding to the dying object.
+
 ## [0.2.5] - 2026-07-01
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This is a substantial change to how enrollment and profile convergence work; it
+warrants a 0.3.0 minor release.
+
+### Added
+
+- **Deleting a `WorkloadProfile` now clears its Redis history.** A cleanup finalizer (`ballast.tightlinesoftware.com/profile-cleanup`) purges the profile's stored metric history before the object is removed. This runs on every deletion path, whether the operator's orphan-TTL sweep or a manual `kubectl delete workloadprofile`. Previously only the TTL sweep purged Redis, so a manual delete orphaned the history in Redis forever. On upgrade, the finalizer is back-filled onto existing profiles on their first reconcile, so no manual migration is required.
+
+- **Prompt convergence watches.** The pod controller now watches `WorkloadProfile` deletions and `BallastConfig` `identityLabels` changes. A deleted profile that still has matching live pods is recreated within seconds (rather than waiting for a pod event or the informer resync period), and an `identityLabels` change promptly migrates affected pods.
+
+### Changed
+
+- **Enrollment is now fully level-triggered on live pod state rather than trusting the stamped `profile-ref`.** Each pod reconcile recomputes the pod's target profile from its current labels and the current `identityLabels`, then reconciles toward it:
+  - **Identity change → migration.** Changing `identityLabels` (or a pod's own identity-label values) moves the pod to the newly-computed profile and recounts the profile it leaves so that profile can orphan and age out.
+  - **Behavior-annotation removal → un-enrollment.** Stripping all Ballast behavior annotations from a running pod now removes its `profile-ref` and finalizer and decrements the profile's `activeWorkloads`. Previously the pod stayed enrolled and kept the profile from orphaning until the pod was deleted.
+  - **Profile deletion with live pods → recreation.** Deleting a profile that still has matching workloads recreates it fresh (history reset) and, because the profile name is a deterministic function of identity, only matching workloads re-reference it.
+
+  Behavior note: deleting a `WorkloadProfile` that still has matching live pods is now a **history reset, not a permanent removal** — the profile regenerates (empty) while matching pods exist. To permanently remove a profile, remove the workload's Ballast annotations (or delete its pods) first, then delete the profile.
+
 ## [0.2.5] - 2026-07-01
 
 ### Added

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -320,13 +320,19 @@ Fires on pod CREATE for pods matching any `ballast.tightlinesoftware.com/*` anno
 
 ### WorkloadWatcher Controller
 
-Watches pods with any `ballast.tightlinesoftware.com/*` annotation.
+Watches pods with any `ballast.tightlinesoftware.com/*` annotation. Enrollment is
+**level-triggered**: every CREATE/UPDATE reconcile recomputes the pod's desired
+profile from its *current* labels and the *current* `identityLabels`, then reconciles
+toward it, rather than trusting the stamped `profile-ref`. The stamp is a cache used
+only on the DELETE path.
 
-- On new pod: resolves identity tuple from labels using the configured tuple definition. Creates `WorkloadProfile` if absent. Increments `activeWorkloads`. Stamps the pod with `ballast.tightlinesoftware.com/profile-ref: <profile-name>` recording the profile assignment at creation time.
-- On pod deletion: reads `ballast.tightlinesoftware.com/profile-ref` from the pod to identify which `WorkloadProfile` to decrement. Does not recompute the tuple. Sets `Orphaned` condition if `activeWorkloads` reaches 0.
-- On orphan TTL expiry: deletes the `WorkloadProfile` and purges its Redis keys.
+- On create/update: if the pod carries a behavior annotation, computes the target profile name, creates the `WorkloadProfile` if absent (recreating it if it was deleted), stamps `ballast.tightlinesoftware.com/profile-ref`, and recomputes `activeWorkloads` from live pods. If the computed name differs from the stamp (a pod-label or `identityLabels` change), the pod **migrates**: it is re-stamped and both the new and old profiles are recounted. If all behavior annotations have been removed, the pod is **un-enrolled**: profile-ref and finalizer removed, old profile decremented.
+- On pod deletion: reads the stamped `profile-ref` (does not recompute — the pod is leaving) to identify which `WorkloadProfile` to recount; sets `Orphaned` when `activeWorkloads` reaches 0.
+- On any profile deletion (orphan-TTL sweep **or** manual `kubectl delete`): a cleanup finalizer purges the profile's Redis keys before the object is removed. Deleting a profile that still has matching live pods is a history reset — the pod watch promptly recreates a fresh profile and re-associates only matching pods.
 
-Using the stamped `profile-ref` rather than recomputing the tuple at deletion time ensures correctness if the tuple definition or pod labels change between a pod's creation and deletion.
+The count is level-triggered (recomputed from live pod state each reconcile), so it self-heals against missed or duplicated events. Prompt convergence is driven by watches (WorkloadProfile deletions, `identityLabels` changes) with the informer resync as the correctness backstop.
+
+**See [docs/convergence.md](docs/convergence.md) for the canonical sequence diagrams and design invariants. Update it when changing enrollment or profile-lifecycle behavior.**
 
 ---
 

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -175,7 +175,7 @@ sequenceDiagram
     ProfR->>API: remove cleanup finalizer → object deleted
     API-->>PodR: WorkloadProfile DELETE (delete-only predicate)
     PodR->>API: podsForProfile → enqueue pods with profile-ref = web
-    Note over PodR: recompute profName = web; ensureProfile recreates it fresh
+    Note over PodR: recompute profName = web<br/>ensureProfile recreates it fresh
     PodR->>API: re-stamp + setActiveWorkloads → count restored
 ```
 

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -27,11 +27,21 @@ them; do not add behavior that violates one without revisiting this document.
    CREATE/UPDATE reconcile recomputes the desired profile from the pod's *current*
    labels and the *current* `identityLabels`, then reconciles toward it. The stamp
    is a cache used only on the DELETE path (where the pod is leaving and there is
-   nothing to recompute).
+   nothing to recompute). The same applies to the profile's own status: each
+   reconcile converges `status.tupleLabels` / `status.selectorLabels` to the
+   recomputed values, so a lost initial status write (conflict, crash, older
+   operator version) heals on the next reconcile of any member pod.
 
 3. **Counts are level-triggered, never incremental.** `setActiveWorkloads` derives
    the count by listing pods and counting live members, so any missed or duplicated
    event self-heals on the next reconcile. It never does `count++/count--`.
+   Both reconcilers enforce this. The pod reconciler recounts promptly on pod
+   events, but only for profiles some pod still references; the profile reconciler
+   independently recounts on every profile event and resync
+   (`recountActiveWorkloads`, write-on-change). The backstop is what heals a
+   profile stranded with a stale count: a lost trailing recount after a migration
+   or un-enrollment, or a pod that vanished without a processed delete event
+   (e.g. its finalizer stripped by hand while the operator was down).
 
 4. **Cleanup lives in the finalizer, and only there.** Redis history is purged by the
    WorkloadProfile cleanup finalizer, so every deletion path (orphan-TTL sweep or
@@ -42,8 +52,17 @@ them; do not add behavior that violates one without revisiting this document.
    The pod controller watches WorkloadProfile deletions and `identityLabels` changes
    so convergence is prompt (seconds). Even if a watch event is missed, the ~10h
    resync re-reconciles every pod and converges. Watch predicates are deliberately
-   narrow (delete-only, identityLabels-only) to avoid enqueue amplification, since
-   profile status is written on every count change.
+   narrow (delete-only; identityLabels-only and filtered to the canonical
+   BallastConfig name) to avoid enqueue amplification, since profile status is
+   written on every count change. BallastConfig *creation* is also admitted: pods
+   reconciled while the config was absent were skipped, and a delete + re-apply
+   never fires the update predicate.
+
+6. **The kill switch defers work; it must not lose it.** Enrollment reconciles
+   skipped while the kill switch is active requeue every minute, so releasing the
+   switch converges promptly (including a one-shot `identityLabels` fan-out that
+   fired mid-outage) instead of waiting for resync. The DELETE path is never
+   suppressed, so accounting stays correct throughout.
 
 ## Participants
 
@@ -90,6 +109,9 @@ sequenceDiagram
 
     API-->>PodR: Pod UPDATE (any change)
     Note over PodR: recompute profName == current stamp → no migration
+    alt profile status labels drifted (recovery)
+        PodR->>API: patch status.tupleLabels / selectorLabels
+    end
     alt finalizer missing (recovery)
         PodR->>API: re-add pod finalizer
     end
@@ -160,7 +182,10 @@ sequenceDiagram
 **Race guard.** If a pod reconciles while the profile is still terminating,
 `ensureProfile` observes the `deletionTimestamp` and returns `errProfileTerminating`;
 the pod requeues rather than binding to the dying object, then recreates once it is
-gone.
+gone. The same guard covers the cache-lag variant: if the cached Get says NotFound
+but the create returns AlreadyExists (the object still exists server-side, either
+terminating or freshly created by a sibling pod), the pod requeues and re-evaluates
+against a fresher cache instead of binding blind.
 
 ```mermaid
 sequenceDiagram
@@ -217,12 +242,52 @@ sequenceDiagram
     PodR->>API: setActiveWorkloads(oldRef) → −1 → orphans when last leaves
 ```
 
+## 8. Count drift — the profile-side backstop
+
+The pod reconciler's recounts fire only for profiles some pod still references. If
+the trailing recount of a migration or un-enrollment is lost (transient API error or
+crash after the pod was already re-stamped or un-enrolled), no pod names the old
+profile anymore and no pod event will ever recount it. The profile reconciler closes
+that hole: on every profile event and on resync it re-derives the count from live pod
+state and patches only when the stored count or Orphaned condition disagrees, so the
+stranded profile still converges to zero, orphans, and ages out.
+
+```mermaid
+sequenceDiagram
+    participant API as K8s API
+    participant ProfR as ProfileReconciler
+
+    API-->>ProfR: WorkloadProfile event (any) or resync
+    ProfR->>API: list pods → derive activeWorkloads
+    alt stored count or Orphaned condition disagrees
+        ProfR->>API: patch status → Orphaned when count is 0
+        Note over ProfR: orphan-TTL countdown starts from this transition
+    end
+```
+
+A momentary interleaving is possible: the backstop can observe a stamp that is not
+yet in its cache and briefly write a lower count. This self-corrects because the
+stamp's own watch event re-triggers the pod reconciler after the cache reflects it;
+the last write always derives from the freshest state.
+
 ## Convergence triggers at a glance
 
 | Change | Prompt trigger | Correctness backstop |
 |---|---|---|
 | Pod created / updated / deleted | Pod watch | resync |
 | `identityLabels` changed | BallastConfig watch (`podsForConfig`) | resync of each pod |
+| BallastConfig deleted + re-applied | BallastConfig watch (create admitted) | resync of each pod |
 | Behavior annotations removed | Pod watch (finalizer keeps it admitted) | resync |
 | Profile deleted (manual or TTL) | WorkloadProfile delete watch (`podsForProfile`) | resync of referencing pods |
+| Stale count / lost trailing recount | WorkloadProfile events (`recountActiveWorkloads`) | resync of the profile |
+| Profile status labels lost | Next reconcile of any member pod | resync |
+| Kill switch released | 1-minute requeue of skipped pods | resync |
 | Redis history on any profile delete | Cleanup finalizer | — (single chokepoint) |
+
+## Known limitations
+
+- **Profile-name collisions.** `sanitizeName` can map two distinct identity tuples to
+  the same profile name (`Web` vs `web`, `a.b` vs `a-b`). Colliding workloads share
+  one profile, and its status labels converge to whichever pod reconciled most
+  recently (visible as the tuple labels flapping between the two identities). Avoid
+  identity-label values that differ only in case or punctuation.

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -1,0 +1,228 @@
+# Convergence Model
+
+> **Canonical reference for enrollment and WorkloadProfile lifecycle.**
+> Humans and AI agents: consult this document before changing anything in
+> `internal/controller/workloadwatcher/` or the WorkloadProfile finalizer. If you
+> change convergence behavior, update the diagrams and invariants here in the same
+> change. The sequence diagrams below are the contract; the code implements them.
+
+Ballast converges every workload to exactly one correct `WorkloadProfile` and keeps
+each profile's `activeWorkloads` count and Redis history accurate, no matter how the
+inputs change (pod churn, annotation edits, `identityLabels` changes, manual profile
+deletion). This document shows how.
+
+## Design invariants
+
+These are the load-bearing principles. Every scenario below is a consequence of
+them; do not add behavior that violates one without revisiting this document.
+
+1. **`profile-ref` is a deterministic function of identity, not an identity itself.**
+   A profile's name is `ProfileName(tupleLabels, identityLabels)`. Any pod with the
+   same identity computes the same name, so re-association after a delete/recreate is
+   automatic and requires no UID/ownerReference bookkeeping. Never model this
+   relationship with `metav1.OwnerReference` (wrong cardinality and wrong cascade
+   direction).
+
+2. **Annotations and stamps are hints, not the source of truth.** Every pod
+   CREATE/UPDATE reconcile recomputes the desired profile from the pod's *current*
+   labels and the *current* `identityLabels`, then reconciles toward it. The stamp
+   is a cache used only on the DELETE path (where the pod is leaving and there is
+   nothing to recompute).
+
+3. **Counts are level-triggered, never incremental.** `setActiveWorkloads` derives
+   the count by listing pods and counting live members, so any missed or duplicated
+   event self-heals on the next reconcile. It never does `count++/count--`.
+
+4. **Cleanup lives in the finalizer, and only there.** Redis history is purged by the
+   WorkloadProfile cleanup finalizer, so every deletion path (orphan-TTL sweep or
+   manual `kubectl delete`) clears history exactly once. The finalizer never reaches
+   out to mutate sibling Pods — each controller repairs its own object.
+
+5. **Watches are for promptness; the informer resync is the correctness backstop.**
+   The pod controller watches WorkloadProfile deletions and `identityLabels` changes
+   so convergence is prompt (seconds). Even if a watch event is missed, the ~10h
+   resync re-reconciles every pod and converges. Watch predicates are deliberately
+   narrow (delete-only, identityLabels-only) to avoid enqueue amplification, since
+   profile status is written on every count change.
+
+## Participants
+
+- **W** — the workload / kubelet / user (`kubectl`, GitOps)
+- **API** — the Kubernetes API server and the controllers' shared informer cache
+- **PodR** — `PodReconciler` (watches Pods; also WorkloadProfile deletes and
+  BallastConfig `identityLabels` changes)
+- **ProfR** — `ProfileReconciler` (watches WorkloadProfile)
+- **Redis** — the metric-history store
+
+---
+
+## 1. Enrollment — a new opted-in pod
+
+```mermaid
+sequenceDiagram
+    participant W as Workload
+    participant API as K8s API
+    participant PodR as PodReconciler
+    participant ProfR as ProfileReconciler
+
+    W->>API: create Pod (measure=true, labels)
+    API-->>PodR: Pod ADD (matches annotation predicate)
+    Note over PodR: hasBehaviorAnnotation → enrolled<br/>recompute profName from labels + identityLabels
+    PodR->>API: ensureProfile(profName) — create if absent
+    API-->>ProfR: WorkloadProfile ADD
+    ProfR->>API: add cleanup finalizer
+    PodR->>API: add pod finalizer
+    PodR->>API: stamp profile-ref = profName
+    PodR->>API: setActiveWorkloads(profName) → count from live pods, clear Orphaned
+```
+
+## 2. Steady state and self-healing recount
+
+Any subsequent reconcile of an already-correct pod is idempotent: the desired name
+equals the stamp, the finalizer is present, and the count is recomputed (a no-op
+status patch when unchanged). A partial prior failure (e.g. finalizer missing) is
+repaired here without double-counting, because the count is level-triggered.
+
+```mermaid
+sequenceDiagram
+    participant API as K8s API
+    participant PodR as PodReconciler
+
+    API-->>PodR: Pod UPDATE (any change)
+    Note over PodR: recompute profName == current stamp → no migration
+    alt finalizer missing (recovery)
+        PodR->>API: re-add pod finalizer
+    end
+    PodR->>API: setActiveWorkloads(profName) → recount (self-heals any drift)
+```
+
+## 3. Pod termination — decrement and orphan transition
+
+```mermaid
+sequenceDiagram
+    participant W as Workload
+    participant API as K8s API
+    participant PodR as PodReconciler
+
+    W->>API: delete Pod
+    Note over API: pod finalizer present → deletionTimestamp set, pod retained
+    API-->>PodR: Pod UPDATE (deletionTimestamp)
+    Note over PodR: DELETE path reads the stamp (no recompute — pod is leaving)
+    PodR->>API: setActiveWorkloads(stampedRef) → pod excluded (deletionTimestamp)
+    Note over API: if count reaches 0 → Orphaned condition set True
+    PodR->>API: remove pod finalizer → pod fully deleted
+```
+
+## 4. Orphan TTL — delete and history purge
+
+The only automated deletion path. It fires only when `activeWorkloads == 0`, so no
+live pod references the profile.
+
+```mermaid
+sequenceDiagram
+    participant ProfR as ProfileReconciler
+    participant API as K8s API
+    participant Redis as Redis
+
+    Note over ProfR: profile Orphaned, age ≥ orphanTTL
+    ProfR->>API: Delete WorkloadProfile
+    Note over API: cleanup finalizer present → deletionTimestamp set, object retained
+    API-->>ProfR: WorkloadProfile UPDATE (terminating)
+    ProfR->>Redis: SCAN + DEL ballast:metrics:<hash>:* (and :first_seen)
+    ProfR->>API: remove cleanup finalizer → object deleted
+```
+
+## 5. Manual delete of a *live* profile — purge, then prompt recreation
+
+Deleting a profile that still has matching pods is a **history reset**, not a
+permanent removal: the finalizer clears Redis, then the pod watch promptly recreates
+a fresh profile and re-associates only the matching pods (invariant 1).
+
+```mermaid
+sequenceDiagram
+    participant U as User (kubectl)
+    participant API as K8s API
+    participant ProfR as ProfileReconciler
+    participant PodR as PodReconciler
+    participant Redis as Redis
+
+    U->>API: kubectl delete workloadprofile web
+    Note over API: cleanup finalizer present → deletionTimestamp set, object retained
+    API-->>ProfR: WorkloadProfile UPDATE (terminating)
+    ProfR->>Redis: purge history
+    ProfR->>API: remove cleanup finalizer → object deleted
+    API-->>PodR: WorkloadProfile DELETE (delete-only predicate)
+    PodR->>API: podsForProfile → enqueue pods with profile-ref = web
+    Note over PodR: recompute profName = web; ensureProfile recreates it fresh
+    PodR->>API: re-stamp + setActiveWorkloads → count restored
+```
+
+**Race guard.** If a pod reconciles while the profile is still terminating,
+`ensureProfile` observes the `deletionTimestamp` and returns `errProfileTerminating`;
+the pod requeues rather than binding to the dying object, then recreates once it is
+gone.
+
+```mermaid
+sequenceDiagram
+    participant API as K8s API
+    participant PodR as PodReconciler
+
+    API-->>PodR: Pod reconcile (profile mid-deletion)
+    PodR->>API: ensureProfile → sees deletionTimestamp
+    Note over PodR: errProfileTerminating → requeue (do not bind)
+    Note over PodR: after object fully deleted → next reconcile recreates fresh
+```
+
+## 6. Identity change — migration
+
+Changing `identityLabels` (cluster-wide, via `BallastConfig`) or a pod's own
+identity-label values changes the pod's computed profile name. The pod migrates and
+the profile it leaves is recounted so it can orphan and age out. A `BallastConfig`
+`identityLabels` edit is made prompt by the config watch; a pod-label change is
+delivered as an ordinary pod update.
+
+```mermaid
+sequenceDiagram
+    participant U as User (GitOps)
+    participant API as K8s API
+    participant PodR as PodReconciler
+
+    U->>API: edit BallastConfig.identityLabels
+    API-->>PodR: BallastConfig UPDATE (identityLabels-changed predicate)
+    PodR->>API: podsForConfig → enqueue all managed pods
+    loop each managed pod
+        Note over PodR: recompute profName(new) ≠ stamp(old) → migrating
+        PodR->>API: ensureProfile(new) + re-stamp profile-ref = new
+        PodR->>API: setActiveWorkloads(new) → +1 (override absorbs cache lag)
+        PodR->>API: setActiveWorkloads(old) → −1 → old orphans when last leaves
+    end
+```
+
+## 7. Behavior-annotation removal — un-enrollment
+
+Removing all Ballast behavior annotations from a running pod un-enrolls it. The pod
+is still admitted (it holds the finalizer), so the reconcile runs and tears down the
+enrollment: stamp and finalizer removed, old profile decremented.
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant API as K8s API
+    participant PodR as PodReconciler
+
+    U->>API: remove behavior annotations from Pod
+    API-->>PodR: Pod UPDATE (still admitted via finalizer)
+    Note over PodR: hasBehaviorAnnotation == false → unenroll
+    PodR->>API: delete profile-ref annotation + remove pod finalizer
+    PodR->>API: setActiveWorkloads(oldRef) → −1 → orphans when last leaves
+```
+
+## Convergence triggers at a glance
+
+| Change | Prompt trigger | Correctness backstop |
+|---|---|---|
+| Pod created / updated / deleted | Pod watch | resync |
+| `identityLabels` changed | BallastConfig watch (`podsForConfig`) | resync of each pod |
+| Behavior annotations removed | Pod watch (finalizer keeps it admitted) | resync |
+| Profile deleted (manual or TTL) | WorkloadProfile delete watch (`podsForProfile`) | resync of referencing pods |
+| Redis history on any profile delete | Cleanup finalizer | — (single chokepoint) |

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -2,6 +2,7 @@ package workloadwatcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -17,6 +18,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
@@ -36,8 +39,22 @@ const (
 
 	FinalizerName = "ballast.tightlinesoftware.com/workloadwatcher"
 
+	// ProfileFinalizerName gates WorkloadProfile deletion so that any delete path
+	// — the operator's orphan-TTL sweep or a manual `kubectl delete` — routes
+	// through the Redis-history purge before the object is released.
+	ProfileFinalizerName = "ballast.tightlinesoftware.com/profile-cleanup"
+
 	conditionOrphaned = "Orphaned"
+
+	// requeueTerminating is how long to wait before re-checking a profile that is
+	// mid-deletion, so a freshly arriving pod is not bound to a doomed profile.
+	requeueTerminating = time.Second
 )
+
+// errProfileTerminating signals that the target WorkloadProfile is mid-deletion
+// (its finalizer is still purging Redis). The pod reconciler translates this into
+// a short requeue rather than binding a live pod to a profile about to disappear.
+var errProfileTerminating = errors.New("workload profile is terminating")
 
 var behaviorAnnotations = []string{
 	AnnotationMeasure,
@@ -116,17 +133,17 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		return ctrl.Result{}, nil
 	}
 
-	// Already processed: ensure finalizer is present for cleanup, then recalibrate.
-	if pod.Annotations[AnnotationProfileRef] != "" {
-		profName := pod.Annotations[AnnotationProfileRef]
-		if !controllerutil.ContainsFinalizer(pod, FinalizerName) {
-			base := pod.DeepCopy()
-			controllerutil.AddFinalizer(pod, FinalizerName)
-			if err := r.client.Patch(ctx, pod, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
-				return ctrl.Result{}, err
-			}
+	currentRef := pod.Annotations[AnnotationProfileRef]
+
+	// Desired enrollment is derived from the pod's live annotations, not from the
+	// stamp. A pod that no longer carries any behavior annotation must be
+	// un-enrolled: drop its profile-ref, remove the finalizer, and recount the
+	// profile it is leaving.
+	if !hasBehaviorAnnotation(pod) {
+		if currentRef != "" || controllerutil.ContainsFinalizer(pod, FinalizerName) {
+			return ctrl.Result{}, r.unenroll(ctx, pod, currentRef)
 		}
-		return ctrl.Result{}, r.setActiveWorkloads(ctx, profName)
+		return ctrl.Result{}, nil
 	}
 
 	var cfg ballastv1.BallastConfig
@@ -138,15 +155,27 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		return ctrl.Result{}, err // coverage:ignore - transient API error
 	}
 
+	// The desired profile name is recomputed from the pod's current identity every
+	// reconcile, so a change to the pod's labels or to identityLabels migrates the
+	// pod to the correct profile instead of trusting a possibly-stale stamp.
 	tupleLabels := ExtractTupleLabels(pod.Labels, cfg.Spec.IdentityLabels)
 	selectorLabels := ExtractSelectorLabels(pod.Labels, cfg.Spec.IdentityLabels)
 	profName := ProfileName(tupleLabels, cfg.Spec.IdentityLabels)
 
-	if err := r.ensureProfile(ctx, profName, tupleLabels, selectorLabels); err != nil { // coverage:ignore - transient API error
-		return ctrl.Result{}, err
+	// Ensure the target profile exists; recreates it if it was deleted while pods
+	// still reference it.
+	if err := r.ensureProfile(ctx, profName, tupleLabels, selectorLabels); err != nil {
+		if errors.Is(err, errProfileTerminating) {
+			// The profile is being purged; wait for it to finish, then a later
+			// reconcile recreates it fresh and rebinds this pod.
+			return ctrl.Result{RequeueAfter: requeueTerminating}, nil
+		}
+		return ctrl.Result{}, err // coverage:ignore - transient API error
 	}
 
 	pid := metrics.ProfileID{Name: profName, Labels: tupleLabels}
+	firstEnroll := currentRef == ""
+	migrating := currentRef != "" && currentRef != profName
 
 	// Add finalizer before stamping the annotation so delete is always handled
 	// even if the annotation stamp fails.
@@ -156,13 +185,50 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 		if err := r.client.Patch(ctx, pod, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
 			return ctrl.Result{}, err
 		}
+	}
+
+	if currentRef != profName {
+		if err := r.stampProfileRef(ctx, pod, profName); err != nil { // coverage:ignore - transient API error
+			return ctrl.Result{}, err
+		}
+	}
+
+	if firstEnroll {
+		r.rec.PodProcessed(ctx, "created", pod.Namespace, pid)
+	}
+	if migrating {
+		r.rec.PodProcessed(ctx, "unenrolled", pod.Namespace, metrics.ProfileID{Name: currentRef})
 		r.rec.PodProcessed(ctx, "created", pod.Namespace, pid)
 	}
 
-	if err := r.stampProfileRef(ctx, pod, profName); err != nil { // coverage:ignore - transient API error
-		return ctrl.Result{}, err
+	// Recount the target profile, treating this pod as bound to profName regardless
+	// of informer cache read-after-write lag on the stamp we just wrote.
+	self := &podEnrollment{namespace: pod.Namespace, name: pod.Name, ref: profName}
+	if migrating {
+		if err := r.setActiveWorkloads(ctx, profName, self); err != nil { // coverage:ignore - transient API error
+			return ctrl.Result{}, err
+		}
+		// Recount the profile the pod just left so it can transition to orphaned.
+		return ctrl.Result{}, r.setActiveWorkloads(ctx, currentRef, self)
 	}
-	return ctrl.Result{}, r.setActiveWorkloads(ctx, profName)
+	return ctrl.Result{}, r.setActiveWorkloads(ctx, profName, self)
+}
+
+// unenroll removes a pod from Ballast management: it drops the profile-ref
+// annotation and the finalizer, then recounts the profile the pod was leaving so
+// that profile can transition to orphaned once its last workload departs.
+func (r *PodReconciler) unenroll(ctx context.Context, pod *corev1.Pod, oldRef string) error {
+	base := pod.DeepCopy()
+	delete(pod.Annotations, AnnotationProfileRef)
+	controllerutil.RemoveFinalizer(pod, FinalizerName)
+	if err := r.client.Patch(ctx, pod, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
+		return err
+	}
+	if oldRef == "" {
+		return nil
+	}
+	r.rec.PodProcessed(ctx, "unenrolled", pod.Namespace, metrics.ProfileID{Name: oldRef})
+	return r.setActiveWorkloads(ctx, oldRef, &podEnrollment{namespace: pod.Namespace, name: pod.Name, ref: ""})
 }
 
 func (r *PodReconciler) handleDelete(ctx context.Context, pod *corev1.Pod) (ctrl.Result, error) {
@@ -177,7 +243,7 @@ func (r *PodReconciler) handleDelete(ctx context.Context, pod *corev1.Pod) (ctrl
 	if profName := pod.Annotations[AnnotationProfileRef]; profName != "" {
 		// The pod has DeletionTimestamp set, so setActiveWorkloads excludes it from
 		// the live count automatically — no separate decrement needed.
-		if err := r.setActiveWorkloads(ctx, profName); err != nil { // coverage:ignore - transient API error
+		if err := r.setActiveWorkloads(ctx, profName, nil); err != nil { // coverage:ignore - transient API error
 			return ctrl.Result{}, err
 		}
 		// Recover the identity-tuple labels from the profile so the "deleted" event
@@ -200,6 +266,12 @@ func (r *PodReconciler) ensureProfile(ctx context.Context, profName string, tupl
 	var existing ballastv1.WorkloadProfile
 	err := r.client.Get(ctx, types.NamespacedName{Name: profName}, &existing)
 	if err == nil {
+		// A profile mid-deletion is having its Redis history purged by the
+		// finalizer. Binding a live pod to it now would race the purge and lose
+		// the freshly-recreated history; signal the caller to requeue instead.
+		if !existing.DeletionTimestamp.IsZero() {
+			return errProfileTerminating
+		}
 		return nil
 	}
 	if !apierrors.IsNotFound(err) { // coverage:ignore - transient API error
@@ -223,12 +295,35 @@ func (r *PodReconciler) ensureProfile(ctx context.Context, profName string, tupl
 	return r.client.Status().Update(ctx, profile)
 }
 
+// podEnrollment overrides the reconciled pod's enrollment when recomputing a
+// profile's active-workload count, so the count reflects the state just written
+// even if the informer cache has not yet caught up (read-after-write lag). A ref
+// of "" treats the pod as un-enrolled.
+type podEnrollment struct {
+	namespace string
+	name      string
+	ref       string
+}
+
+// hasBehaviorAnnotation reports whether the pod carries at least one Ballast
+// behavior annotation, i.e. whether it wants to be enrolled.
+func hasBehaviorAnnotation(pod *corev1.Pod) bool {
+	for _, ann := range behaviorAnnotations {
+		if _, ok := pod.Annotations[ann]; ok {
+			return true
+		}
+	}
+	return false
+}
+
 // setActiveWorkloads counts all pods that hold our finalizer, carry a profileRef
 // matching profName, and have no DeletionTimestamp, then writes that count to the
 // WorkloadProfile status. This is level-triggered: each call derives the count from
 // actual pod state rather than incrementing/decrementing, making every reconcile
-// idempotent and self-healing against any prior miscounting.
-func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string) error {
+// idempotent and self-healing against any prior miscounting. When self is non-nil,
+// the matching pod's enrollment is overridden with self.ref so the count is correct
+// despite cache lag on a stamp written earlier in the same reconcile.
+func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string, self *podEnrollment) error {
 	var podList corev1.PodList
 	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
 		return err
@@ -237,9 +332,13 @@ func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string)
 	var count int32
 	for i := range podList.Items {
 		p := &podList.Items[i]
-		if p.Annotations[AnnotationProfileRef] == profName &&
-			controllerutil.ContainsFinalizer(p, FinalizerName) &&
-			p.DeletionTimestamp.IsZero() {
+		ref := p.Annotations[AnnotationProfileRef]
+		enrolled := controllerutil.ContainsFinalizer(p, FinalizerName)
+		if self != nil && p.Namespace == self.namespace && p.Name == self.name {
+			ref = self.ref
+			enrolled = self.ref != ""
+		}
+		if ref == profName && enrolled && p.DeletionTimestamp.IsZero() {
 			count++
 		}
 	}
@@ -291,12 +390,86 @@ func HasBallastAnnotationOrFinalizer(obj client.Object) bool {
 	return slices.Contains(obj.GetFinalizers(), FinalizerName)
 }
 
-// SetupWithManager registers the PodReconciler with the manager.
+// podsForProfile maps a WorkloadProfile event to reconcile requests for every pod
+// that references it by name, so a deleted profile promptly re-reconciles (and thus
+// recreates for) the workloads that still point at it.
+func (r *PodReconciler) podsForProfile(ctx context.Context, obj client.Object) []ctrl.Request {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+		return nil
+	}
+	var reqs []ctrl.Request
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if p.Annotations[AnnotationProfileRef] == obj.GetName() {
+			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: p.Namespace, Name: p.Name}})
+		}
+	}
+	return reqs
+}
+
+// podsForConfig maps a BallastConfig change to reconcile requests for every managed
+// pod, so an identityLabels change promptly migrates each pod to its new profile.
+func (r *PodReconciler) podsForConfig(ctx context.Context, _ client.Object) []ctrl.Request {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+		return nil
+	}
+	var reqs []ctrl.Request
+	for i := range podList.Items {
+		p := &podList.Items[i]
+		if hasBehaviorAnnotation(p) || controllerutil.ContainsFinalizer(p, FinalizerName) {
+			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: p.Namespace, Name: p.Name}})
+		}
+	}
+	return reqs
+}
+
+// profileDeleted admits only WorkloadProfile delete events. Status writes happen on
+// every pod change, so admitting updates here would enqueue the referencing pods on
+// each write and amplify work without cause.
+func profileDeleted() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}
+
+// identityLabelsChanged admits only BallastConfig updates that change the identity
+// label set — the single field that alters profile names.
+func identityLabelsChanged() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCfg, ok1 := e.ObjectOld.(*ballastv1.BallastConfig)
+			newCfg, ok2 := e.ObjectNew.(*ballastv1.BallastConfig)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return !slices.Equal(oldCfg.Spec.IdentityLabels, newCfg.Spec.IdentityLabels)
+		},
+	}
+}
+
+// SetupWithManager registers the PodReconciler with the manager. Beyond watching
+// pods, it watches WorkloadProfile deletions (to promptly recreate profiles still
+// referenced by live pods) and BallastConfig identityLabels changes (to promptly
+// migrate pods to their new profiles).
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("workloadwatcher-pod").
 		WithLogConstructor(logger.ControllerLogConstructor(mgr.GetLogger(), "workloadwatcher-pod")).
 		For(&corev1.Pod{}, builder.WithPredicates(predicate.NewPredicateFuncs(HasBallastAnnotationOrFinalizer))).
+		Watches(&ballastv1.WorkloadProfile{},
+			handler.EnqueueRequestsFromMapFunc(r.podsForProfile),
+			builder.WithPredicates(profileDeleted())).
+		Watches(&ballastv1.BallastConfig{},
+			handler.EnqueueRequestsFromMapFunc(r.podsForConfig),
+			builder.WithPredicates(identityLabelsChanged())).
 		Complete(r)
 }
 
@@ -307,17 +480,38 @@ type ProfileReconciler struct {
 	rec         *metrics.Recorder
 }
 
-// Reconcile checks whether an orphaned profile has exceeded its TTL and, if so,
-// purges its Redis data and deletes the profile object.
+// Reconcile enforces the profile lifecycle. It runs the Redis-history purge for
+// profiles that are being deleted (the finalizer path), ensures the cleanup
+// finalizer is present on live profiles, and deletes profiles that have been
+// orphaned past their TTL. Cleanup itself lives entirely in the finalizer, so it
+// runs regardless of whether the delete was triggered by the TTL sweep or by an
+// operator running `kubectl delete`.
 func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	var profile ballastv1.WorkloadProfile
 	if err := r.client.Get(ctx, req.NamespacedName, &profile); err != nil { // coverage:ignore - transient API error
-		if apierrors.IsNotFound(err) { // coverage:ignore - transient API error
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err // coverage:ignore - transient non-NotFound error
 	}
 
+	// Deletion in progress: run the finalizer (purge Redis, release the object).
+	if !profile.DeletionTimestamp.IsZero() {
+		return r.finalize(ctx, &profile)
+	}
+
+	// Ensure the cleanup finalizer is present so every future deletion routes
+	// through finalize. This also back-fills the finalizer onto profiles created
+	// by an older operator version on their first reconcile after upgrade.
+	if !controllerutil.ContainsFinalizer(&profile, ProfileFinalizerName) {
+		base := profile.DeepCopy()
+		controllerutil.AddFinalizer(&profile, ProfileFinalizerName)
+		if err := r.client.Patch(ctx, &profile, client.MergeFrom(base)); err != nil { // coverage:ignore - transient API error
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Orphan-TTL policy decides *when* to delete; the finalizer decides *how* to clean up.
 	cond := apimeta.FindStatusCondition(profile.Status.Conditions, conditionOrphaned)
 	if cond == nil || cond.Status != metav1.ConditionTrue {
 		return ctrl.Result{}, nil
@@ -341,6 +535,21 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{RequeueAfter: ttl - age}, nil
 	}
 
+	// Deleting only sets the DeletionTimestamp; the finalizer runs on the next
+	// reconcile and performs the Redis purge before the object is removed.
+	if err := r.client.Delete(ctx, &profile); err != nil { // coverage:ignore - transient API error
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, nil
+}
+
+// finalize purges the profile's Redis history and removes the cleanup finalizer,
+// allowing the API server to complete the deletion.
+func (r *ProfileReconciler) finalize(ctx context.Context, profile *ballastv1.WorkloadProfile) (ctrl.Result, error) {
+	if !controllerutil.ContainsFinalizer(profile, ProfileFinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
 	tupleHash := store.TupleHash(profile.Status.TupleLabels)
 	keys, err := store.AllKeysForHash(ctx, r.storeClient, tupleHash)
 	if err != nil { // coverage:ignore - requires a broken Redis instance
@@ -351,12 +560,11 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			return ctrl.Result{}, err
 		}
 	}
-
-	if err := r.client.Delete(ctx, &profile); err != nil { // coverage:ignore - transient API error
-		return ctrl.Result{}, err
-	}
 	r.rec.WorkloadProfilePurged(ctx, metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels})
-	return ctrl.Result{}, nil
+
+	base := profile.DeepCopy()
+	controllerutil.RemoveFinalizer(profile, ProfileFinalizerName)
+	return ctrl.Result{}, r.client.Patch(ctx, profile, client.MergeFrom(base)) // coverage:ignore - transient API error on the patch itself
 }
 
 // SetupWithManager registers the ProfileReconciler with the manager.

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 	"time"
@@ -49,6 +50,14 @@ const (
 	// requeueTerminating is how long to wait before re-checking a profile that is
 	// mid-deletion, so a freshly arriving pod is not bound to a doomed profile.
 	requeueTerminating = time.Second
+
+	// requeueKillSwitch is how often a managed pod re-reconciles while the kill
+	// switch is active. The kill switch is level state with no deactivation event
+	// wired to pods, so without this requeue any enrollment work skipped while it
+	// was active (including a one-shot identityLabels fan-out) would wait for the
+	// informer resync. Reconciles under the kill switch are read-only, so this is
+	// cheap even fleet-wide.
+	requeueKillSwitch = time.Minute
 )
 
 // errProfileTerminating signals that the target WorkloadProfile is mid-deletion
@@ -130,7 +139,7 @@ func (r *PodReconciler) handleCreateUpdate(ctx context.Context, pod *corev1.Pod)
 	if r.ks.IsActive() {
 		log.Info("kill switch active, skipping pod",
 			"kill_switch", true, "kill_switch_reason", r.ks.Reason())
-		return ctrl.Result{}, nil
+		return ctrl.Result{RequeueAfter: requeueKillSwitch}, nil
 	}
 
 	currentRef := pod.Annotations[AnnotationProfileRef]
@@ -272,7 +281,7 @@ func (r *PodReconciler) ensureProfile(ctx context.Context, profName string, tupl
 		if !existing.DeletionTimestamp.IsZero() {
 			return errProfileTerminating
 		}
-		return nil
+		return r.ensureProfileStatus(ctx, &existing, tupleLabels, selectorLabels)
 	}
 	if !apierrors.IsNotFound(err) { // coverage:ignore - transient API error
 		return err
@@ -281,18 +290,39 @@ func (r *PodReconciler) ensureProfile(ctx context.Context, profName string, tupl
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
-	if err := r.client.Create(ctx, profile); err != nil { // coverage:ignore - transient API error
-		if apierrors.IsAlreadyExists(err) { // coverage:ignore - create/create race
-			return nil
+	if err := r.client.Create(ctx, profile); err != nil {
+		if apierrors.IsAlreadyExists(err) {
+			// The cache said NotFound but the API server has the object: either a
+			// concurrent create by another pod's reconcile or a deletion that has
+			// not completed server-side. Requeue and re-evaluate against a fresher
+			// cache rather than guessing which; binding now could attach the pod
+			// to an object mid-purge.
+			return errProfileTerminating
 		}
 		return err // coverage:ignore - transient non-AlreadyExists error
 	}
 	r.rec.WorkloadProfileCreated(ctx, metrics.ProfileID{Name: profName, Labels: tupleLabels})
 
-	// Status is a subresource; must be updated after creation.
+	// Status is a subresource; it can only be written after creation.
+	return r.ensureProfileStatus(ctx, profile, tupleLabels, selectorLabels)
+}
+
+// ensureProfileStatus level-triggers the profile's identity labels: whenever the
+// stored status does not match the desired tuple/selector labels, patch it.
+// Converging on every reconcile (not only at creation) heals a profile whose
+// initial status write was lost — a conflict with the profile reconciler's
+// concurrent finalizer back-fill, a crash between create and status write, or a
+// profile inherited from an older operator version. A Patch (not Update) is used
+// so the write cannot 409 against that finalizer back-fill.
+func (r *PodReconciler) ensureProfileStatus(ctx context.Context, profile *ballastv1.WorkloadProfile, tupleLabels, selectorLabels map[string]string) error {
+	if maps.Equal(profile.Status.TupleLabels, tupleLabels) &&
+		maps.Equal(profile.Status.SelectorLabels, selectorLabels) {
+		return nil
+	}
+	base := profile.DeepCopy()
 	profile.Status.TupleLabels = tupleLabels
 	profile.Status.SelectorLabels = selectorLabels
-	return r.client.Status().Update(ctx, profile)
+	return r.client.Status().Patch(ctx, profile, client.MergeFrom(base))
 }
 
 // podEnrollment overrides the reconciled pod's enrollment when recomputing a
@@ -316,22 +346,14 @@ func hasBehaviorAnnotation(pod *corev1.Pod) bool {
 	return false
 }
 
-// setActiveWorkloads counts all pods that hold our finalizer, carry a profileRef
-// matching profName, and have no DeletionTimestamp, then writes that count to the
-// WorkloadProfile status. This is level-triggered: each call derives the count from
-// actual pod state rather than incrementing/decrementing, making every reconcile
-// idempotent and self-healing against any prior miscounting. When self is non-nil,
-// the matching pod's enrollment is overridden with self.ref so the count is correct
+// countActiveWorkloads counts pods that hold our finalizer, carry a profileRef
+// matching profName, and have no DeletionTimestamp. When self is non-nil, the
+// matching pod's enrollment is overridden with self.ref so the count is correct
 // despite cache lag on a stamp written earlier in the same reconcile.
-func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string, self *podEnrollment) error {
-	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
-		return err
-	}
-
+func countActiveWorkloads(pods []corev1.Pod, profName string, self *podEnrollment) int32 {
 	var count int32
-	for i := range podList.Items {
-		p := &podList.Items[i]
+	for i := range pods {
+		p := &pods[i]
 		ref := p.Annotations[AnnotationProfileRef]
 		enrolled := controllerutil.ContainsFinalizer(p, FinalizerName)
 		if self != nil && p.Namespace == self.namespace && p.Name == self.name {
@@ -342,15 +364,12 @@ func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string,
 			count++
 		}
 	}
+	return count
+}
 
-	var profile ballastv1.WorkloadProfile
-	if err := r.client.Get(ctx, types.NamespacedName{Name: profName}, &profile); err != nil { // coverage:ignore - transient API error
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-		return err // coverage:ignore - transient non-NotFound error
-	}
-	base := profile.DeepCopy()
+// setWorkloadCount records count on the profile status and maintains the Orphaned
+// condition: set when the count reaches zero, removed otherwise.
+func setWorkloadCount(profile *ballastv1.WorkloadProfile, count int32) {
 	profile.Status.ActiveWorkloads = count
 	if count == 0 {
 		apimeta.SetStatusCondition(&profile.Status.Conditions, metav1.Condition{
@@ -363,6 +382,28 @@ func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string,
 	} else {
 		apimeta.RemoveStatusCondition(&profile.Status.Conditions, conditionOrphaned)
 	}
+}
+
+// setActiveWorkloads derives the profile's active-workload count from actual pod
+// state and writes it to the WorkloadProfile status. This is level-triggered:
+// each call recomputes rather than incrementing/decrementing, making every
+// reconcile idempotent and self-healing against any prior miscounting.
+func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string, self *podEnrollment) error {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+		return err
+	}
+	count := countActiveWorkloads(podList.Items, profName, self)
+
+	var profile ballastv1.WorkloadProfile
+	if err := r.client.Get(ctx, types.NamespacedName{Name: profName}, &profile); err != nil { // coverage:ignore - transient API error
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err // coverage:ignore - transient non-NotFound error
+	}
+	base := profile.DeepCopy()
+	setWorkloadCount(&profile, count)
 	return r.client.Status().Patch(ctx, &profile, client.MergeFrom(base))
 }
 
@@ -437,17 +478,23 @@ func profileDeleted() predicate.Predicate {
 	}
 }
 
-// identityLabelsChanged admits only BallastConfig updates that change the identity
-// label set — the single field that alters profile names.
+// identityLabelsChanged admits only the canonical BallastConfig events that can
+// change enrollment outcomes: creation (pods reconciled while the config was
+// absent were skipped, and a delete + re-apply with different identityLabels never
+// fires the update path) and updates that change the identity label set — the
+// single field that alters profile names. The name filter matches the killswitch's
+// own BallastConfig watch, so a stray non-canonical object cannot fan out
+// reconciles for the whole fleet.
 func identityLabelsChanged() predicate.Predicate {
+	canonical := func(obj client.Object) bool { return obj.GetName() == killswitch.BallastConfigName }
 	return predicate.Funcs{
-		CreateFunc:  func(event.CreateEvent) bool { return false },
+		CreateFunc:  func(e event.CreateEvent) bool { return canonical(e.Object) },
 		DeleteFunc:  func(event.DeleteEvent) bool { return false },
 		GenericFunc: func(event.GenericEvent) bool { return false },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			oldCfg, ok1 := e.ObjectOld.(*ballastv1.BallastConfig)
 			newCfg, ok2 := e.ObjectNew.(*ballastv1.BallastConfig)
-			if !ok1 || !ok2 {
+			if !ok1 || !ok2 || !canonical(e.ObjectNew) {
 				return false
 			}
 			return !slices.Equal(oldCfg.Spec.IdentityLabels, newCfg.Spec.IdentityLabels)
@@ -511,6 +558,17 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		}
 	}
 
+	// Correctness backstop for counts: recompute activeWorkloads from live pod
+	// state. The pod reconciler's recounts are the prompt path, but they fire only
+	// for profiles some pod still references; if the trailing recount of a
+	// migration or un-enrollment is lost (transient API error, operator crash), no
+	// pod names the old profile anymore and no pod event will ever recount it.
+	// Recounting here — on every profile event and on resync — guarantees such a
+	// profile still converges to zero, orphans, and ages out.
+	if err := r.recountActiveWorkloads(ctx, &profile); err != nil { // coverage:ignore - transient API error
+		return ctrl.Result{}, err
+	}
+
 	// Orphan-TTL policy decides *when* to delete; the finalizer decides *how* to clean up.
 	cond := apimeta.FindStatusCondition(profile.Status.Conditions, conditionOrphaned)
 	if cond == nil || cond.Status != metav1.ConditionTrue {
@@ -541,6 +599,28 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{}, nil
+}
+
+// recountActiveWorkloads level-triggers profile.Status.ActiveWorkloads from live
+// pod state, writing only when the stored count or Orphaned condition disagrees.
+// The write-on-change guard keeps this from generating a status event (and thus
+// another profile reconcile) on the steady-state path.
+func (r *ProfileReconciler) recountActiveWorkloads(ctx context.Context, profile *ballastv1.WorkloadProfile) error {
+	var podList corev1.PodList
+	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+		return err
+	}
+	count := countActiveWorkloads(podList.Items, profile.Name, nil)
+
+	cond := apimeta.FindStatusCondition(profile.Status.Conditions, conditionOrphaned)
+	orphaned := cond != nil && cond.Status == metav1.ConditionTrue
+	if profile.Status.ActiveWorkloads == count && orphaned == (count == 0) {
+		return nil
+	}
+
+	base := profile.DeepCopy()
+	setWorkloadCount(profile, count)
+	return r.client.Status().Patch(ctx, profile, client.MergeFrom(base))
 }
 
 // finalize purges the profile's Redis history and removes the cleanup finalizer,

--- a/internal/controller/workloadwatcher/controller_test.go
+++ b/internal/controller/workloadwatcher/controller_test.go
@@ -726,6 +726,206 @@ func TestPodReconciler_SpecialLabelChars(t *testing.T) {
 	}
 }
 
+// TestPodReconciler_BarePodIgnored reconciles a pod with no behavior annotation,
+// no profile-ref, and no finalizer (e.g. a stray requeue): it must be a no-op.
+func TestPodReconciler_BarePodIgnored(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bare",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "web"},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), pod)
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "bare")
+
+	var list ballastv1.WorkloadProfileList
+	if err := fc.List(ctx, &list); err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("expected no profiles for a bare pod, got %d", len(list.Items))
+	}
+}
+
+// TestPodReconciler_UnenrollOnAnnotationRemoval verifies that stripping a pod's
+// behavior annotation un-enrolls it: profile-ref and finalizer removed, count
+// decremented, profile orphaned once its last workload leaves.
+func TestPodReconciler_UnenrollOnAnnotationRemoval(t *testing.T) {
+	ctx := context.Background()
+	profName := "web"
+	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			// No behavior annotation — only the stamp and finalizer remain.
+			Annotations: map[string]string{workloadwatcher.AnnotationProfileRef: profName},
+			Labels:      map[string]string{"app": "web"},
+			Finalizers:  []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile, pod)
+	profile.Status.ActiveWorkloads = 1
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "web-abc")
+
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-abc"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if ref := gotPod.Annotations[workloadwatcher.AnnotationProfileRef]; ref != "" {
+		t.Errorf("profile-ref should be cleared on un-enroll, got %q", ref)
+	}
+	for _, f := range gotPod.Finalizers {
+		if f == workloadwatcher.FinalizerName {
+			t.Error("finalizer should be removed on un-enroll")
+		}
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if got.Status.ActiveWorkloads != 0 {
+		t.Errorf("activeWorkloads: got %d, want 0 after un-enroll", got.Status.ActiveWorkloads)
+	}
+	if cond := apimeta.FindStatusCondition(got.Status.Conditions, "Orphaned"); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Error("expected Orphaned condition True after last workload un-enrolls")
+	}
+}
+
+// TestPodReconciler_UnenrollNoProfileRef covers the edge where a pod holds our
+// finalizer but never received a profile-ref (and carries no behavior annotation):
+// the finalizer must still be stripped, with no recount attempted.
+func TestPodReconciler_UnenrollNoProfileRef(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "web-abc",
+			Namespace:  "default",
+			Labels:     map[string]string{"app": "web"},
+			Finalizers: []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), pod)
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "web-abc")
+
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-abc"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	for _, f := range gotPod.Finalizers {
+		if f == workloadwatcher.FinalizerName {
+			t.Error("finalizer should be removed even without a profile-ref")
+		}
+	}
+}
+
+// TestPodReconciler_MigrateOnLabelChange verifies that when a pod's identity no
+// longer maps to its stamped profile, it migrates: re-stamped to the new profile
+// (created, count 1) and the old profile recounted to 0 and orphaned.
+func TestPodReconciler_MigrateOnLabelChange(t *testing.T) {
+	ctx := context.Background()
+	oldName, newName := "stale", "web"
+	oldProfile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: oldName}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				workloadwatcher.AnnotationMeasure:    "true",
+				workloadwatcher.AnnotationProfileRef: oldName,
+			},
+			Labels:     map[string]string{"app": "web"},
+			Finalizers: []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), oldProfile, pod)
+	oldProfile.Status.ActiveWorkloads = 1
+	if err := fc.Status().Update(ctx, oldProfile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "web-abc")
+
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-abc"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if ref := gotPod.Annotations[workloadwatcher.AnnotationProfileRef]; ref != newName {
+		t.Errorf("profile-ref: got %q, want %q", ref, newName)
+	}
+
+	var newProf ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: newName}, &newProf); err != nil {
+		t.Fatalf("Get new profile: %v", err)
+	}
+	if newProf.Status.ActiveWorkloads != 1 {
+		t.Errorf("new profile activeWorkloads: got %d, want 1", newProf.Status.ActiveWorkloads)
+	}
+
+	var oldProf ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: oldName}, &oldProf); err != nil {
+		t.Fatalf("Get old profile: %v", err)
+	}
+	if oldProf.Status.ActiveWorkloads != 0 {
+		t.Errorf("old profile activeWorkloads: got %d, want 0", oldProf.Status.ActiveWorkloads)
+	}
+	if cond := apimeta.FindStatusCondition(oldProf.Status.Conditions, "Orphaned"); cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Error("expected old profile to be orphaned after migration")
+	}
+}
+
+// TestPodReconciler_MigrateOnIdentityLabelsChange verifies that expanding
+// identityLabels moves a pod to the newly-computed profile name.
+func TestPodReconciler_MigrateOnIdentityLabelsChange(t *testing.T) {
+	ctx := context.Background()
+	cfg := &ballastv1.BallastConfig{
+		ObjectMeta: metav1.ObjectMeta{Name: killswitch.BallastConfigName},
+		Spec:       ballastv1.BallastConfigSpec{IdentityLabels: []string{"app", "tier"}, OrphanTTL: "168h"},
+	}
+	oldProfile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: "web"}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				workloadwatcher.AnnotationMeasure:    "true",
+				workloadwatcher.AnnotationProfileRef: "web",
+			},
+			Labels:     map[string]string{"app": "web", "tier": "api"},
+			Finalizers: []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(cfg, oldProfile, pod)
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "web-abc")
+
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-abc"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if ref := gotPod.Annotations[workloadwatcher.AnnotationProfileRef]; ref != "web--api" {
+		t.Errorf("profile-ref after identityLabels change: got %q, want %q", ref, "web--api")
+	}
+	var newProf ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: "web--api"}, &newProf); err != nil {
+		t.Fatalf("Get migrated profile: %v", err)
+	}
+	if newProf.Status.ActiveWorkloads != 1 {
+		t.Errorf("migrated profile activeWorkloads: got %d, want 1", newProf.Status.ActiveWorkloads)
+	}
+}
+
 // -- ExtractTupleLabels unit tests --
 
 func TestExtractTupleLabels(t *testing.T) {
@@ -980,9 +1180,26 @@ func TestProfileReconciler_OrphanTTLExpired(t *testing.T) {
 	}
 
 	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
-	_, err := reconcileProfile(t, c, profName)
-	if err != nil {
-		t.Fatalf("Profile.Reconcile: %v", err)
+
+	// First reconcile adds the finalizer and issues the delete, which only sets
+	// the DeletionTimestamp because the finalizer now holds the object.
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile (delete): %v", err)
+	}
+	var terminating ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &terminating); err != nil {
+		t.Fatalf("profile should still exist mid-deletion: %v", err)
+	}
+	if terminating.DeletionTimestamp.IsZero() {
+		t.Error("expected DeletionTimestamp to be set after orphan-TTL delete")
+	}
+	if len(mr.Keys()) == 0 {
+		t.Error("Redis keys should survive until the finalizer runs")
+	}
+
+	// Second reconcile runs the finalizer: it purges Redis and releases the object.
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile (finalize): %v", err)
 	}
 
 	// Profile must be deleted.
@@ -1079,9 +1296,167 @@ func TestProfileReconciler_RedisFailure(t *testing.T) {
 	mr.Close() // shut down the server so Redis commands fail
 
 	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
-	_, err := reconcileProfile(t, c, profName)
-	if err == nil {
+
+	// First reconcile only issues the delete (no Redis I/O) and must succeed.
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile (delete) should not touch Redis: %v", err)
+	}
+
+	// Second reconcile runs the finalizer, which must fail against dead Redis.
+	if _, err := reconcileProfile(t, c, profName); err == nil {
 		t.Fatal("expected error when Redis is unavailable, got nil")
+	}
+}
+
+func TestProfileReconciler_AddsFinalizer(t *testing.T) {
+	ctx := context.Background()
+	profName := "web"
+	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+
+	_, rc := newMiniredisClient(t)
+	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
+
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	found := false
+	for _, f := range got.Finalizers {
+		if f == workloadwatcher.ProfileFinalizerName {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected cleanup finalizer to be added, finalizers=%v", got.Finalizers)
+	}
+}
+
+// TestProfileReconciler_ManualDeletePurgesRedis proves the finalizer runs the
+// Redis purge even when the delete was user-initiated rather than orphan-TTL
+// driven — the whole point of moving cleanup into the finalizer.
+func TestProfileReconciler_ManualDeletePurgesRedis(t *testing.T) {
+	ctx := context.Background()
+	profName := "web"
+	tupleLabels := map[string]string{"app": "web"}
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       profName,
+			Finalizers: []string{workloadwatcher.ProfileFinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+
+	profile.Status.TupleLabels = tupleLabels
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	mr, rc := newMiniredisClient(t)
+	tupleHash := store.TupleHash(tupleLabels)
+	key := store.MetricKey(tupleHash, "app", "cpu")
+	if err := store.AddSample(ctx, rc, key, 1000, "100m", 0); err != nil {
+		t.Fatalf("AddSample: %v", err)
+	}
+
+	// Manual delete: the finalizer keeps the object alive until Redis is purged.
+	if err := fc.Delete(ctx, profile); err != nil {
+		t.Fatalf("delete profile: %v", err)
+	}
+
+	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile (finalize): %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); !apierrors.IsNotFound(err) {
+		t.Errorf("expected profile to be deleted, got err=%v", err)
+	}
+	if remaining := mr.Keys(); len(remaining) != 0 {
+		t.Errorf("expected Redis keys purged on manual delete, remaining: %v", remaining)
+	}
+}
+
+// TestProfileReconciler_FinalizeWithoutFinalizer covers the defensive no-op path:
+// a profile being deleted that never carried our finalizer (held alive here by a
+// foreign one) must be left untouched.
+func TestProfileReconciler_FinalizeWithoutFinalizer(t *testing.T) {
+	ctx := context.Background()
+	profName := "web"
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       profName,
+			Finalizers: []string{"other.io/keep"},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+
+	if err := fc.Delete(ctx, profile); err != nil {
+		t.Fatalf("delete profile: %v", err)
+	}
+
+	_, rc := newMiniredisClient(t)
+	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
+
+	if _, err := reconcileProfile(t, c, profName); err != nil {
+		t.Fatalf("Profile.Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
+		t.Fatalf("profile should still exist (foreign finalizer holds it): %v", err)
+	}
+}
+
+// TestPodReconciler_ProfileTerminatingRequeues covers the delete/recreate race
+// guard: a new pod arriving while its profile is mid-deletion must requeue rather
+// than bind to the doomed profile.
+func TestPodReconciler_ProfileTerminatingRequeues(t *testing.T) {
+	ctx := context.Background()
+	profile := &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "web",
+			Finalizers: []string{workloadwatcher.ProfileFinalizerName},
+		},
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "web-pod",
+			Namespace:   "default",
+			Annotations: map[string]string{workloadwatcher.AnnotationMeasure: "true"},
+			Labels:      map[string]string{"app": "web"},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile, pod)
+	if err := fc.Delete(ctx, profile); err != nil {
+		t.Fatalf("delete profile: %v", err)
+	}
+
+	_, rc := newMiniredisClient(t)
+	c := workloadwatcher.New(fc, inactiveKS(t), rc, nil)
+
+	result, err := c.Pod.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "web-pod"},
+	})
+	if err != nil {
+		t.Fatalf("Pod.Reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected a requeue while the profile is terminating")
+	}
+
+	// The pod must not have been bound to the doomed profile.
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-pod"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if ref := gotPod.Annotations[workloadwatcher.AnnotationProfileRef]; ref != "" {
+		t.Errorf("pod should not be stamped with profileRef while profile terminating, got %q", ref)
 	}
 }
 

--- a/internal/controller/workloadwatcher/controller_test.go
+++ b/internal/controller/workloadwatcher/controller_test.go
@@ -14,11 +14,13 @@ import (
 	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -255,7 +257,18 @@ func TestPodReconciler_KillSwitchSuppresses(t *testing.T) {
 	fc := newFakeClient(defaultBallastConfig(), pod)
 	c := workloadwatcher.New(fc, activeKS(t), nil, nil)
 
-	reconcilePod(t, c, "default", "web-abc")
+	result, err := c.Pod.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "web-abc"},
+	})
+	if err != nil {
+		t.Fatalf("Pod.Reconcile: %v", err)
+	}
+	// The kill switch has no deactivation event wired to pods, so the reconcile
+	// must requeue; otherwise enrollment skipped while the switch was active would
+	// wait for the informer resync after release.
+	if result.RequeueAfter == 0 {
+		t.Error("expected a requeue while the kill switch is active")
+	}
 
 	var list ballastv1.WorkloadProfileList
 	if err := fc.List(ctx, &list); err != nil {
@@ -926,6 +939,95 @@ func TestPodReconciler_MigrateOnIdentityLabelsChange(t *testing.T) {
 	}
 }
 
+// TestPodReconciler_HealsMissingStatusLabels covers the level-triggered status
+// convergence in ensureProfile: a profile whose initial status write was lost
+// (conflict with the finalizer back-fill, crash between create and status write,
+// or created by an older operator version) must get its tuple/selector labels
+// repaired on the next reconcile of any member pod.
+func TestPodReconciler_HealsMissingStatusLabels(t *testing.T) {
+	ctx := context.Background()
+	profName := "web"
+	// Profile exists but its status labels were never written.
+	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				workloadwatcher.AnnotationMeasure:    "true",
+				workloadwatcher.AnnotationProfileRef: profName,
+			},
+			Labels:     map[string]string{"app": "web"},
+			Finalizers: []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile, pod)
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+	reconcilePod(t, c, "default", "web-abc")
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if got.Status.TupleLabels["app"] != "web" {
+		t.Errorf("tupleLabels[app]: got %q, want %q (status labels must be healed)", got.Status.TupleLabels["app"], "web")
+	}
+	if got.Status.SelectorLabels["app"] != "web" {
+		t.Errorf("selectorLabels[app]: got %q, want %q (status labels must be healed)", got.Status.SelectorLabels["app"], "web")
+	}
+}
+
+// TestPodReconciler_CreateRaceRequeues covers the cache-lag race on profile
+// creation: the cached Get says NotFound but the API server still has the object
+// (a concurrent create, or a deletion that has not completed server-side), so
+// Create returns AlreadyExists. The reconcile must requeue rather than bind the
+// pod to an object it could not inspect.
+func TestPodReconciler_CreateRaceRequeues(t *testing.T) {
+	ctx := context.Background()
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "web-pod",
+			Namespace:   "default",
+			Annotations: map[string]string{workloadwatcher.AnnotationMeasure: "true"},
+			Labels:      map[string]string{"app": "web"},
+		},
+	}
+	fc := fake.NewClientBuilder().
+		WithScheme(newScheme()).
+		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithObjects(defaultBallastConfig(), pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+				if _, ok := obj.(*ballastv1.WorkloadProfile); ok {
+					return apierrors.NewAlreadyExists(
+						schema.GroupResource{Group: "ballast.tightlinesoftware.com", Resource: "workloadprofiles"},
+						obj.GetName())
+				}
+				return c.Create(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	c := workloadwatcher.New(fc, inactiveKS(t), nil, nil)
+
+	result, err := c.Pod.Reconcile(ctx, reconcile.Request{
+		NamespacedName: types.NamespacedName{Namespace: "default", Name: "web-pod"},
+	})
+	if err != nil {
+		t.Fatalf("Pod.Reconcile: %v", err)
+	}
+	if result.RequeueAfter == 0 {
+		t.Error("expected a requeue when profile create hits AlreadyExists through a stale cache")
+	}
+
+	var gotPod corev1.Pod
+	if err := fc.Get(ctx, types.NamespacedName{Namespace: "default", Name: "web-pod"}, &gotPod); err != nil {
+		t.Fatalf("Get pod: %v", err)
+	}
+	if ref := gotPod.Annotations[workloadwatcher.AnnotationProfileRef]; ref != "" {
+		t.Errorf("pod should not be stamped during the create race, got profile-ref %q", ref)
+	}
+}
+
 // -- ExtractTupleLabels unit tests --
 
 func TestExtractTupleLabels(t *testing.T) {
@@ -1039,7 +1141,21 @@ func TestProfileReconciler_NotOrphaned(t *testing.T) {
 	profile := &ballastv1.WorkloadProfile{
 		ObjectMeta: metav1.ObjectMeta{Name: profName},
 	}
-	fc := newFakeClient(defaultBallastConfig(), profile)
+	// A live enrolled pod keeps the profile non-orphaned through the backstop
+	// recount. Its stored count is stale (0); the recount must correct it upward.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "web-abc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				workloadwatcher.AnnotationMeasure:    "true",
+				workloadwatcher.AnnotationProfileRef: profName,
+			},
+			Labels:     map[string]string{"app": "web"},
+			Finalizers: []string{workloadwatcher.FinalizerName},
+		},
+	}
+	fc := newFakeClient(defaultBallastConfig(), profile, pod)
 
 	_, mr := newMiniredisClient(t)
 	c := workloadwatcher.New(fc, inactiveKS(t), mr, nil)
@@ -1052,10 +1168,57 @@ func TestProfileReconciler_NotOrphaned(t *testing.T) {
 		t.Errorf("expected no requeue for non-orphaned profile, got RequeueAfter=%v", result.RequeueAfter)
 	}
 
-	// Profile must still exist.
+	// Profile must still exist, with the backstop recount fixing the stale count.
 	var got ballastv1.WorkloadProfile
 	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
 		t.Fatalf("Get profile: %v", err)
+	}
+	if got.Status.ActiveWorkloads != 1 {
+		t.Errorf("activeWorkloads: got %d, want 1 (backstop recount should correct upward)", got.Status.ActiveWorkloads)
+	}
+	if cond := apimeta.FindStatusCondition(got.Status.Conditions, "Orphaned"); cond != nil && cond.Status == metav1.ConditionTrue {
+		t.Error("expected no Orphaned condition while an enrolled pod exists")
+	}
+}
+
+// TestProfileReconciler_RecountHealsStaleCount covers the count backstop: a
+// profile stranded with a stale non-zero count and no referencing pods (e.g. the
+// trailing recount of a migration was lost to a transient error) must be
+// recounted to zero and orphaned by the profile reconciler itself, so it can age
+// out and be purged.
+func TestProfileReconciler_RecountHealsStaleCount(t *testing.T) {
+	ctx := context.Background()
+
+	profName := "stale"
+	profile := &ballastv1.WorkloadProfile{ObjectMeta: metav1.ObjectMeta{Name: profName}}
+	fc := newFakeClient(defaultBallastConfig(), profile)
+	profile.Status.ActiveWorkloads = 1 // stale: no pod references this profile
+	if err := fc.Status().Update(ctx, profile); err != nil {
+		t.Fatalf("status update: %v", err)
+	}
+
+	_, mr := newMiniredisClient(t)
+	c := workloadwatcher.New(fc, inactiveKS(t), mr, nil)
+
+	result, err := reconcileProfile(t, c, profName)
+	if err != nil {
+		t.Fatalf("Profile.Reconcile: %v", err)
+	}
+
+	var got ballastv1.WorkloadProfile
+	if err := fc.Get(ctx, types.NamespacedName{Name: profName}, &got); err != nil {
+		t.Fatalf("Get profile: %v", err)
+	}
+	if got.Status.ActiveWorkloads != 0 {
+		t.Errorf("activeWorkloads: got %d, want 0 (backstop recount should heal stale count)", got.Status.ActiveWorkloads)
+	}
+	cond := apimeta.FindStatusCondition(got.Status.Conditions, "Orphaned")
+	if cond == nil || cond.Status != metav1.ConditionTrue {
+		t.Fatal("expected Orphaned condition True after backstop recount")
+	}
+	// The orphan-TTL countdown starts from the recount's transition time.
+	if result.RequeueAfter == 0 {
+		t.Error("expected a TTL requeue once the profile is orphaned")
 	}
 }
 
@@ -1535,14 +1698,9 @@ func TestController_SetupWithManager(t *testing.T) {
 	// Wait for WorkloadProfile to appear.
 	waitForProfile(t, ctx, c, "web")
 
-	// Verify activeWorkloads=1.
-	var profile ballastv1.WorkloadProfile
-	if err := c.Get(ctx, types.NamespacedName{Name: "web"}, &profile); err != nil {
-		t.Fatalf("Get WorkloadProfile: %v", err)
-	}
-	if profile.Status.ActiveWorkloads != 1 {
-		t.Errorf("activeWorkloads: got %d, want 1", profile.Status.ActiveWorkloads)
-	}
+	// Wait for activeWorkloads=1: the pod reconciler's recount and the profile
+	// reconciler's backstop recount converge on it, but may interleave briefly.
+	waitForActiveWorkloads(t, ctx, c, "web", 1)
 
 	// Delete the pod and wait for the Orphaned condition to be set.
 	if err := c.Delete(ctx, pod); err != nil {
@@ -1562,6 +1720,23 @@ func waitForProfile(t *testing.T, ctx context.Context, c client.Client, name str
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Errorf("timed out waiting for WorkloadProfile %q to appear", name)
+}
+
+func waitForActiveWorkloads(t *testing.T, ctx context.Context, c client.Client, name string, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(15 * time.Second)
+	var last int32
+	for time.Now().Before(deadline) {
+		var p ballastv1.WorkloadProfile
+		if err := c.Get(ctx, types.NamespacedName{Name: name}, &p); err == nil {
+			last = p.Status.ActiveWorkloads
+			if last == want {
+				return
+			}
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Errorf("timed out waiting for WorkloadProfile %q activeWorkloads=%d, last seen %d", name, want, last)
 }
 
 func waitForOrphaned(t *testing.T, ctx context.Context, c client.Client, name string) {

--- a/internal/controller/workloadwatcher/watch_internal_test.go
+++ b/internal/controller/workloadwatcher/watch_internal_test.go
@@ -1,0 +1,108 @@
+package workloadwatcher
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+)
+
+// These tests live in the internal package so they can exercise the unexported
+// watch predicates and map functions directly, covering every closure branch.
+
+func internalScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = ballastv1.AddToScheme(s)
+	return s
+}
+
+func TestProfileDeletedPredicate(t *testing.T) {
+	p := profileDeleted()
+	if p.Create(event.CreateEvent{}) {
+		t.Error("create should not be admitted")
+	}
+	if p.Update(event.UpdateEvent{}) {
+		t.Error("update should not be admitted")
+	}
+	if p.Generic(event.GenericEvent{}) {
+		t.Error("generic should not be admitted")
+	}
+	if !p.Delete(event.DeleteEvent{}) {
+		t.Error("delete should be admitted")
+	}
+}
+
+func TestIdentityLabelsChangedPredicate(t *testing.T) {
+	p := identityLabelsChanged()
+	if p.Create(event.CreateEvent{}) {
+		t.Error("create should not be admitted")
+	}
+	if p.Delete(event.DeleteEvent{}) {
+		t.Error("delete should not be admitted")
+	}
+	if p.Generic(event.GenericEvent{}) {
+		t.Error("generic should not be admitted")
+	}
+
+	mk := func(labels ...string) *ballastv1.BallastConfig {
+		return &ballastv1.BallastConfig{Spec: ballastv1.BallastConfigSpec{IdentityLabels: labels}}
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: mk("app"), ObjectNew: mk("app")}) {
+		t.Error("update with unchanged identityLabels should not be admitted")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: mk("app"), ObjectNew: mk("app", "tier")}) {
+		t.Error("update with changed identityLabels should be admitted")
+	}
+	// Non-BallastConfig objects → type assertion fails → not admitted.
+	if p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{}}) {
+		t.Error("update with non-BallastConfig objects should not be admitted")
+	}
+}
+
+func TestPodsForProfile(t *testing.T) {
+	match := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "m", Namespace: "default",
+		Annotations: map[string]string{AnnotationProfileRef: "web"},
+	}}
+	other := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "o", Namespace: "default",
+		Annotations: map[string]string{AnnotationProfileRef: "db"},
+	}}
+	fc := fake.NewClientBuilder().WithScheme(internalScheme()).WithObjects(match, other).Build()
+	r := &PodReconciler{client: fc}
+
+	reqs := r.podsForProfile(context.Background(), &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "web"},
+	})
+	if len(reqs) != 1 || reqs[0].Name != "m" {
+		t.Errorf("podsForProfile: got %v, want a single request for pod m", reqs)
+	}
+}
+
+func TestPodsForConfig(t *testing.T) {
+	managed := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "m", Namespace: "default",
+		Finalizers: []string{FinalizerName},
+	}}
+	annotated := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: "a", Namespace: "default",
+		Annotations: map[string]string{AnnotationMeasure: "true"},
+	}}
+	unmanaged := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "u", Namespace: "default"}}
+	fc := fake.NewClientBuilder().WithScheme(internalScheme()).
+		WithObjects(managed, annotated, unmanaged).Build()
+	r := &PodReconciler{client: fc}
+
+	reqs := r.podsForConfig(context.Background(), &ballastv1.BallastConfig{})
+	if len(reqs) != 2 {
+		t.Errorf("podsForConfig: got %d requests, want 2 (managed + annotated)", len(reqs))
+	}
+}

--- a/internal/controller/workloadwatcher/watch_internal_test.go
+++ b/internal/controller/workloadwatcher/watch_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
+	"github.com/tight-line/ballast/internal/killswitch"
 )
 
 // These tests live in the internal package so they can exercise the unexported
@@ -42,8 +43,24 @@ func TestProfileDeletedPredicate(t *testing.T) {
 
 func TestIdentityLabelsChangedPredicate(t *testing.T) {
 	p := identityLabelsChanged()
-	if p.Create(event.CreateEvent{}) {
-		t.Error("create should not be admitted")
+
+	mkNamed := func(name string, labels ...string) *ballastv1.BallastConfig {
+		return &ballastv1.BallastConfig{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec:       ballastv1.BallastConfigSpec{IdentityLabels: labels},
+		}
+	}
+	mk := func(labels ...string) *ballastv1.BallastConfig {
+		return mkNamed(killswitch.BallastConfigName, labels...)
+	}
+
+	// Creation of the canonical config is admitted: pods reconciled while it was
+	// absent were skipped, and a delete + re-apply never fires the update path.
+	if !p.Create(event.CreateEvent{Object: mk("app")}) {
+		t.Error("create of the canonical BallastConfig should be admitted")
+	}
+	if p.Create(event.CreateEvent{Object: mkNamed("stray", "app")}) {
+		t.Error("create of a non-canonical BallastConfig should not be admitted")
 	}
 	if p.Delete(event.DeleteEvent{}) {
 		t.Error("delete should not be admitted")
@@ -52,14 +69,14 @@ func TestIdentityLabelsChangedPredicate(t *testing.T) {
 		t.Error("generic should not be admitted")
 	}
 
-	mk := func(labels ...string) *ballastv1.BallastConfig {
-		return &ballastv1.BallastConfig{Spec: ballastv1.BallastConfigSpec{IdentityLabels: labels}}
-	}
 	if p.Update(event.UpdateEvent{ObjectOld: mk("app"), ObjectNew: mk("app")}) {
 		t.Error("update with unchanged identityLabels should not be admitted")
 	}
 	if !p.Update(event.UpdateEvent{ObjectOld: mk("app"), ObjectNew: mk("app", "tier")}) {
 		t.Error("update with changed identityLabels should be admitted")
+	}
+	if p.Update(event.UpdateEvent{ObjectOld: mkNamed("stray", "app"), ObjectNew: mkNamed("stray", "app", "tier")}) {
+		t.Error("update of a non-canonical BallastConfig should not be admitted")
 	}
 	// Non-BallastConfig objects → type assertion fails → not admitted.
 	if p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{}}) {


### PR DESCRIPTION
## Summary

Reworks WorkloadProfile enrollment and lifecycle so a workload always converges to the correct profile, and a profile's Redis history is always cleaned up on deletion. This is a substantial change to how enrollment and convergence work and **warrants a 0.3.0 minor release** (version bump happens at release time via `scripts/make-tag`).

The canonical reference for all of this is the new **[docs/convergence.md](docs/convergence.md)** (sequence diagrams + design invariants). DESIGN.md and AGENTS.md were updated to match and to route future humans and agents there before touching enrollment/convergence code.

## What changed

**1. Profile history is cleared on every deletion path.** A cleanup finalizer (`ballast.tightlinesoftware.com/profile-cleanup`) purges the profile's Redis keys before the object is removed, whether the deletion comes from the orphan-TTL sweep or a manual `kubectl delete workloadprofile`. Previously only the TTL sweep purged Redis; a manual delete orphaned the history forever. The finalizer is back-filled onto existing profiles on their first reconcile, so upgrading needs no manual migration.

**2. Enrollment is now level-triggered.** Each pod CREATE/UPDATE reconcile recomputes the target profile from the pod's current labels and the current `identityLabels` instead of trusting the stamped `profile-ref` (the stamp is now a hint, trusted verbatim only on the DELETE path). This makes three things converge that previously did not:

- **Identity change → migration.** Changing `identityLabels` (or a pod's identity-label values) moves the pod to the newly-computed profile and recounts the profile it leaves so that profile can orphan and age out.
- **Behavior-annotation removal → un-enrollment.** Stripping all Ballast behavior annotations from a running pod removes its `profile-ref` and finalizer and decrements the profile's `activeWorkloads`.
- **Profile deletion with live pods → recreation.** Deleting a profile that still has matching workloads recreates it fresh; because the profile name is a deterministic function of identity, only matching workloads re-reference it.

**3. Prompt convergence via watches.** The pod controller now watches WorkloadProfile deletions (delete-only predicate) and BallastConfig `identityLabels` changes (identityLabels-only predicate), so recreation/migration happens in seconds rather than waiting for the pod's next event or the ~10h informer resync. The narrow predicates avoid enqueue amplification, since profile status is written on every count change. Resync remains the correctness backstop.

**4. Cache-lag-safe counts.** `setActiveWorkloads` stays level-triggered (recomputes from live pods, never `++/--`); a per-reconcile enrollment override keeps the count correct despite informer cache read-after-write lag on a stamp just written.

## Behavior note (documented in CHANGELOG + convergence.md)

Deleting a `WorkloadProfile` that still has matching live pods is now a **history reset, not a permanent removal** — the profile regenerates (empty) while matching pods exist. To permanently remove one, remove the workload's Ballast annotations (or delete its pods) first, then delete the profile.

## Scope boundary

The workloadwatcher owns enrollment (in/out) only. The *specific* behavior a pod gets (`measure`/`apply`/`resize`) is enforced by the resourceadjuster (reads live annotations each cycle) and the admission webhook (admission-time only). Changing an annotation on a running pod does not retroactively re-mutate its resources via the webhook; that applies on the pod's next admission.

## Testing

- New unit tests for un-enrollment, migration (label change and identityLabels change), the profile-terminating race guard, recreation on delete, and the watch predicates/map functions (internal test file, exercising every closure branch).
- `make lint` — 0 issues.
- `make test-coverage-check` — passes (100% gate; workloadwatcher up to 87.7%).