### PR TITLE
fix: serve activeWorkloads recounts from a profile-ref pod index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sustained full-CPU load on clusters with many pods.** Every `activeWorkloads` recount listed and deep-copied every pod in the cluster from the informer cache. The profile reconciler introduced in 0.3.0 performs such a recount on every `WorkloadProfile` event, including the metrics collector's once-per-poll status writes, so on a large cluster (thousands of pods, hundreds of profiles) the operator burned most of a core continuously, starting at startup and never settling. Pod lookups by profile now go through a cache field index keyed on the `profile-ref` annotation, so each recount touches only that profile's members. The pod reconciler's recounts and the profile-deletion fan-out use the same index. Counting semantics are unchanged, including the same-reconcile stamp override that keeps counts correct despite informer cache lag.
+
 ## [0.3.0] - 2026-07-01
 
 This is a substantial change to how enrollment and profile convergence work; it

--- a/docs/convergence.md
+++ b/docs/convergence.md
@@ -33,15 +33,30 @@ them; do not add behavior that violates one without revisiting this document.
    operator version) heals on the next reconcile of any member pod.
 
 3. **Counts are level-triggered, never incremental.** `setActiveWorkloads` derives
-   the count by listing pods and counting live members, so any missed or duplicated
-   event self-heals on the next reconcile. It never does `count++/count--`.
-   Both reconcilers enforce this. The pod reconciler recounts promptly on pod
-   events, but only for profiles some pod still references; the profile reconciler
-   independently recounts on every profile event and resync
+   the count by listing the profile's member pods and counting live ones, so any
+   missed or duplicated event self-heals on the next reconcile. It never does
+   `count++/count--`. Both reconcilers enforce this. The pod reconciler recounts
+   promptly on pod events, but only for profiles some pod still references; the
+   profile reconciler independently recounts on every profile event and resync
    (`recountActiveWorkloads`, write-on-change). The backstop is what heals a
    profile stranded with a stale count: a lost trailing recount after a migration
    or un-enrollment, or a pod that vanished without a processed delete event
    (e.g. its finalizer stripped by hand while the operator was down).
+
+   Every recount lists pods through the `PodProfileRefField` cache index (keyed on
+   the profile-ref annotation), so its cost scales with the profile's membership,
+   not the cluster's pod count. This is load-bearing: the profile reconciler's
+   backstop fires on *every* profile status write, including the metrics
+   collector's once-per-poll patches, and an unindexed list would deep-copy
+   every pod in the cluster on each of those, pinning a core indefinitely on
+   large clusters. The index reflects the *cached* annotation, so a pod stamped
+   earlier in the same reconcile is usually still indexed under its old ref;
+   `countActiveWorkloads` compensates via the self override, which both excludes
+   the pod from its old profile's list and inserts it into its new profile's
+   count when the index has not yet caught up. Do not filter profile update
+   events with a predicate instead; resync delivers update events with
+   `old == new`, so any field-diff predicate would also drop the resync events
+   the backstop depends on.
 
 4. **Cleanup lives in the finalizer, and only there.** Redis history is purged by the
    WorkloadProfile cleanup finalizer, so every deletion path (orphan-TTL sweep or
@@ -258,7 +273,7 @@ sequenceDiagram
     participant ProfR as ProfileReconciler
 
     API-->>ProfR: WorkloadProfile event (any) or resync
-    ProfR->>API: list pods → derive activeWorkloads
+    ProfR->>API: list pods by profile-ref index → derive activeWorkloads
     alt stored count or Orphaned condition disagrees
         ProfR->>API: patch status → Orphaned when count is 0
         Note over ProfR: orphan-TTL countdown starts from this transition

--- a/internal/controller/workloadwatcher/controller.go
+++ b/internal/controller/workloadwatcher/controller.go
@@ -40,6 +40,14 @@ const (
 
 	FinalizerName = "ballast.tightlinesoftware.com/workloadwatcher"
 
+	// PodProfileRefField is the cache index key for looking up pods by their
+	// profile-ref annotation. It is registered in PodReconciler.SetupWithManager;
+	// test harnesses using a fake client must register it with
+	// WithIndex(&corev1.Pod{}, PodProfileRefField, PodProfileRefIndexer).
+	// Without it, every count recomputation would list and deep-copy every pod
+	// in the cluster on each reconcile.
+	PodProfileRefField = ".metadata.annotations.profile-ref"
+
 	// ProfileFinalizerName gates WorkloadProfile deletion so that any delete path
 	// — the operator's orphan-TTL sweep or a manual `kubectl delete` — routes
 	// through the Redis-history purge before the object is released.
@@ -350,19 +358,32 @@ func hasBehaviorAnnotation(pod *corev1.Pod) bool {
 // matching profName, and have no DeletionTimestamp. When self is non-nil, the
 // matching pod's enrollment is overridden with self.ref so the count is correct
 // despite cache lag on a stamp written earlier in the same reconcile.
+//
+// pods comes from the profile-ref index, which reflects the *cached* annotation.
+// A pod stamped with profName earlier in this same reconcile is usually still
+// indexed under its previous ref, so it is absent from the list entirely; the
+// override can only exclude pods, never admit them. The insert below closes that
+// half: when self claims profName but did not appear, count it in by hand. No
+// DeletionTimestamp check is needed there because handleCreateUpdate (the only
+// caller passing a non-nil self) never runs for terminating pods.
 func countActiveWorkloads(pods []corev1.Pod, profName string, self *podEnrollment) int32 {
 	var count int32
+	seenSelf := false
 	for i := range pods {
 		p := &pods[i]
 		ref := p.Annotations[AnnotationProfileRef]
 		enrolled := controllerutil.ContainsFinalizer(p, FinalizerName)
 		if self != nil && p.Namespace == self.namespace && p.Name == self.name {
+			seenSelf = true
 			ref = self.ref
 			enrolled = self.ref != ""
 		}
 		if ref == profName && enrolled && p.DeletionTimestamp.IsZero() {
 			count++
 		}
+	}
+	if self != nil && !seenSelf && self.ref == profName {
+		count++
 	}
 	return count
 }
@@ -387,10 +408,12 @@ func setWorkloadCount(profile *ballastv1.WorkloadProfile, count int32) {
 // setActiveWorkloads derives the profile's active-workload count from actual pod
 // state and writes it to the WorkloadProfile status. This is level-triggered:
 // each call recomputes rather than incrementing/decrementing, making every
-// reconcile idempotent and self-healing against any prior miscounting.
+// reconcile idempotent and self-healing against any prior miscounting. The list
+// is served by the profile-ref index, so its cost scales with the profile's
+// membership, not the cluster's pod count.
 func (r *PodReconciler) setActiveWorkloads(ctx context.Context, profName string, self *podEnrollment) error {
 	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+	if err := r.client.List(ctx, &podList, client.MatchingFields{PodProfileRefField: profName}); err != nil { // coverage:ignore - transient API error
 		return err
 	}
 	count := countActiveWorkloads(podList.Items, profName, self)
@@ -431,20 +454,29 @@ func HasBallastAnnotationOrFinalizer(obj client.Object) bool {
 	return slices.Contains(obj.GetFinalizers(), FinalizerName)
 }
 
+// PodProfileRefIndexer extracts the profile-ref annotation as the index key for
+// PodProfileRefField. Pods without the annotation are not indexed. Exported so
+// tests can register the same index on a fake client.
+func PodProfileRefIndexer(obj client.Object) []string {
+	if ref := obj.GetAnnotations()[AnnotationProfileRef]; ref != "" {
+		return []string{ref}
+	}
+	return nil
+}
+
 // podsForProfile maps a WorkloadProfile event to reconcile requests for every pod
-// that references it by name, so a deleted profile promptly re-reconciles (and thus
-// recreates for) the workloads that still point at it.
+// that references it by name (served by the profile-ref index), so a deleted
+// profile promptly re-reconciles (and thus recreates for) the workloads that
+// still point at it.
 func (r *PodReconciler) podsForProfile(ctx context.Context, obj client.Object) []ctrl.Request {
 	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+	if err := r.client.List(ctx, &podList, client.MatchingFields{PodProfileRefField: obj.GetName()}); err != nil { // coverage:ignore - transient API error
 		return nil
 	}
 	var reqs []ctrl.Request
 	for i := range podList.Items {
 		p := &podList.Items[i]
-		if p.Annotations[AnnotationProfileRef] == obj.GetName() {
-			reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: p.Namespace, Name: p.Name}})
-		}
+		reqs = append(reqs, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: p.Namespace, Name: p.Name}})
 	}
 	return reqs
 }
@@ -505,8 +537,15 @@ func identityLabelsChanged() predicate.Predicate {
 // SetupWithManager registers the PodReconciler with the manager. Beyond watching
 // pods, it watches WorkloadProfile deletions (to promptly recreate profiles still
 // referenced by live pods) and BallastConfig identityLabels changes (to promptly
-// migrate pods to their new profiles).
+// migrate pods to their new profiles). It also registers the profile-ref pod
+// index on the manager's shared cache, which serves both this reconciler's and
+// the ProfileReconciler's count lookups.
 func (r *PodReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	if err := mgr.GetFieldIndexer().IndexField(
+		context.Background(), &corev1.Pod{}, PodProfileRefField, PodProfileRefIndexer,
+	); err != nil { // coverage:ignore - fails only on duplicate index registration
+		return fmt.Errorf("registering pod profile-ref index: %w", err)
+	}
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("workloadwatcher-pod").
 		WithLogConstructor(logger.ControllerLogConstructor(mgr.GetLogger(), "workloadwatcher-pod")).
@@ -604,10 +643,14 @@ func (r *ProfileReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // recountActiveWorkloads level-triggers profile.Status.ActiveWorkloads from live
 // pod state, writing only when the stored count or Orphaned condition disagrees.
 // The write-on-change guard keeps this from generating a status event (and thus
-// another profile reconcile) on the steady-state path.
+// another profile reconcile) on the steady-state path. The indexed list matters
+// here even more than on the pod side: this runs on *every* profile event,
+// including the metrics collector's once-per-poll status writes, so an
+// unindexed list would deep-copy the whole cluster's pods several times a
+// second, forever.
 func (r *ProfileReconciler) recountActiveWorkloads(ctx context.Context, profile *ballastv1.WorkloadProfile) error {
 	var podList corev1.PodList
-	if err := r.client.List(ctx, &podList); err != nil { // coverage:ignore - transient API error
+	if err := r.client.List(ctx, &podList, client.MatchingFields{PodProfileRefField: profile.Name}); err != nil { // coverage:ignore - transient API error
 		return err
 	}
 	count := countActiveWorkloads(podList.Items, profile.Name, nil)

--- a/internal/controller/workloadwatcher/controller_test.go
+++ b/internal/controller/workloadwatcher/controller_test.go
@@ -45,6 +45,7 @@ func newFakeClient(objs ...client.Object) client.Client {
 	return fake.NewClientBuilder().
 		WithScheme(newScheme()).
 		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithIndex(&corev1.Pod{}, workloadwatcher.PodProfileRefField, workloadwatcher.PodProfileRefIndexer).
 		WithObjects(objs...).
 		Build()
 }
@@ -995,6 +996,7 @@ func TestPodReconciler_CreateRaceRequeues(t *testing.T) {
 	fc := fake.NewClientBuilder().
 		WithScheme(newScheme()).
 		WithStatusSubresource(&ballastv1.WorkloadProfile{}).
+		WithIndex(&corev1.Pod{}, workloadwatcher.PodProfileRefField, workloadwatcher.PodProfileRefIndexer).
 		WithObjects(defaultBallastConfig(), pod).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {

--- a/internal/controller/workloadwatcher/watch_internal_test.go
+++ b/internal/controller/workloadwatcher/watch_internal_test.go
@@ -93,7 +93,11 @@ func TestPodsForProfile(t *testing.T) {
 		Name: "o", Namespace: "default",
 		Annotations: map[string]string{AnnotationProfileRef: "db"},
 	}}
-	fc := fake.NewClientBuilder().WithScheme(internalScheme()).WithObjects(match, other).Build()
+	fc := fake.NewClientBuilder().
+		WithScheme(internalScheme()).
+		WithIndex(&corev1.Pod{}, PodProfileRefField, PodProfileRefIndexer).
+		WithObjects(match, other).
+		Build()
 	r := &PodReconciler{client: fc}
 
 	reqs := r.podsForProfile(context.Background(), &ballastv1.WorkloadProfile{
@@ -121,5 +125,92 @@ func TestPodsForConfig(t *testing.T) {
 	reqs := r.podsForConfig(context.Background(), &ballastv1.BallastConfig{})
 	if len(reqs) != 2 {
 		t.Errorf("podsForConfig: got %d requests, want 2 (managed + annotated)", len(reqs))
+	}
+}
+
+// enrolledPod builds a pod carrying the given profile-ref and our finalizer, as
+// countActiveWorkloads expects index-served list items to look.
+func enrolledPod(name, ref string) corev1.Pod {
+	return corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Name: name, Namespace: "default",
+		Annotations: map[string]string{AnnotationProfileRef: ref},
+		Finalizers:  []string{FinalizerName},
+	}}
+}
+
+// TestCountActiveWorkloads pins the self-override semantics against an
+// index-served pod list, which reflects the cached (possibly pre-stamp)
+// profile-ref annotation:
+//   - a pod newly stamped in the same reconcile is still indexed under its old
+//     ref, so it is absent from the new profile's list and must be inserted;
+//   - the same pod does appear in the old profile's list and must be excluded.
+//
+// A refactor that drops the insert half silently undercounts the target profile
+// after every migration and first enrollment.
+func TestCountActiveWorkloads(t *testing.T) {
+	self := &podEnrollment{namespace: "default", name: "migrating", ref: "new"}
+
+	tests := []struct {
+		name     string
+		pods     []corev1.Pod
+		profName string
+		self     *podEnrollment
+		want     int32
+	}{
+		{
+			name:     "self absent from target profile's indexed list is inserted",
+			pods:     []corev1.Pod{enrolledPod("other", "new")},
+			profName: "new",
+			self:     self,
+			want:     2,
+		},
+		{
+			name:     "self present under old ref is excluded from the old profile",
+			pods:     []corev1.Pod{enrolledPod("migrating", "old"), enrolledPod("stays", "old")},
+			profName: "old",
+			self:     self,
+			want:     1,
+		},
+		{
+			name:     "self present under target ref is not double-counted",
+			pods:     []corev1.Pod{enrolledPod("migrating", "new")},
+			profName: "new",
+			self:     self,
+			want:     1,
+		},
+		{
+			name:     "un-enrolling self (empty ref) is excluded and never inserted",
+			pods:     []corev1.Pod{enrolledPod("migrating", "old")},
+			profName: "old",
+			self:     &podEnrollment{namespace: "default", name: "migrating", ref: ""},
+			want:     0,
+		},
+		{
+			name: "nil self counts only live finalized pods",
+			pods: []corev1.Pod{
+				enrolledPod("live", "web"),
+				func() corev1.Pod {
+					p := enrolledPod("terminating", "web")
+					now := metav1.Now()
+					p.DeletionTimestamp = &now
+					return p
+				}(),
+				{ObjectMeta: metav1.ObjectMeta{
+					Name: "no-finalizer", Namespace: "default",
+					Annotations: map[string]string{AnnotationProfileRef: "web"},
+				}},
+			},
+			profName: "web",
+			self:     nil,
+			want:     1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countActiveWorkloads(tt.pods, tt.profName, tt.self); got != tt.want {
+				t.Errorf("countActiveWorkloads(%q) = %d, want %d", tt.profName, got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

Upgrading from 0.2.5 to 0.3.0 pegs a full CPU core indefinitely on large clusters (observed: ~5,000 pods, ~250 profiles).

Every `activeWorkloads` recount called `client.List` with no filter, which walks and deep-copies **every pod in the cluster** from the informer cache. That cost existed on the pod-reconcile path before 0.3.0, but 0.3.0's `ProfileReconciler` added `recountActiveWorkloads` on **every** WorkloadProfile event, and the metrics collector patches every profile's status once per poll interval (default 60s). At 250 profiles that is ~4 profile events/sec, each deep-copying 5,000 pods: a standing load that starts at operator startup and never settles.

## Fix

Register a cache field index (`PodProfileRefField`) keyed on the `profile-ref` annotation, and serve all pod-by-profile lookups from it:

- `PodReconciler.setActiveWorkloads` (prompt recounts on pod events)
- `ProfileReconciler.recountActiveWorkloads` (the per-event correctness backstop)
- `podsForProfile` (profile-deletion fan-out)

Each recount now touches only that profile's members instead of the whole cluster. `podsForConfig` intentionally keeps the full list: it fires only on `identityLabels` changes, and its job is a whole-fleet fan-out.

An alternative approach, predicate-filtering the profile reconciler's update events, was rejected because informer resync delivers update events with `old == new`, so any field-diff predicate would also drop the resync events the count backstop depends on. `docs/convergence.md` now records this.

## Correctness note: the `self` override

The index reflects the *cached* annotation. A pod stamped with its new profile earlier in the same reconcile is usually still indexed under its old ref, so it is **absent** from the new profile's indexed list; the existing `self` override could only exclude pods from a list, never admit missing ones. `countActiveWorkloads` now inserts the reconciled pod by hand when it claims the counted profile but was not returned by the index. Without this, every migration and first enrollment would undercount the target profile by one. Pinned by `TestCountActiveWorkloads`.

## Testing

- New table-driven `TestCountActiveWorkloads` covering insert-if-missing, exclude-from-old, no-double-count, un-enroll, and nil-self cases
- Fake clients in the test harness register the same index via `WithIndex`; the envtest integration test exercises the real `IndexField` registration
- `make lint`: 0 issues; `make test-coverage-check`: passed at 76.3%