### PR TITLE
fix: keep CRDs in sync on helm upgrade via apply-crds hook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,3 +9,6 @@
 # Re-include Go module files
 !go.mod
 !go.sum
+
+# Re-include the CRD manifests embedded into the binary (config/crd/bases/embed.go)
+!config/crd/bases/*.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **CRD changes now apply on `helm upgrade`.** Helm installs the chart's `crds/` directory only on first install and never upgrades it, so every CRD change since a cluster's initial install was silently skipped (first visible symptom: 0.3.2's `STATE` printer column never appearing). A new pre-install/pre-upgrade hook Job runs `ballastd apply-crds`, a new operator subcommand that server-side-applies the CRD manifests baked into the image at build time (field manager `ballast-crd-installer`, force ownership). Applies are atomic and idempotent, so re-runs, concurrent runs, and manual invocations are all safe; running as `pre-install` also means the installer owns the CRD fields from day one, avoiding server-side-apply ownership conflicts with the initial Helm install. Disable with `crds.upgradeHook.enabled: false` if CRDs are managed by external tooling (upgrades then require applying `config/crd/bases/` by hand). The `crds/` directory remains for first-install bootstrapping, since Helm validates templated resources against cluster discovery before hooks run.
+
 ## [0.3.2] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ helm install ballast ballast/ballast \
 
 The chart ships with a sensible default for `ballastConfig.identityLabels` (`app.kubernetes.io/name` + `app.kubernetes.io/component`). Read the section below before overriding it — the choice has cluster-wide consequences.
 
+Upgrades are `helm upgrade --install` with no extra steps. CRDs are kept in sync automatically: Helm itself never upgrades the `crds/` directory, so the chart runs a pre-install/pre-upgrade hook Job (`ballastd apply-crds`) that server-side-applies the CRD manifests baked into the operator image. Set `crds.upgradeHook.enabled: false` to opt out if external tooling manages CRDs; you are then responsible for applying `config/crd/bases/` on every upgrade.
+
 ## WorkloadProfile Identity
 
 Ballast groups pods into `WorkloadProfile` objects by matching a configurable set of pod label keys called the **identity tuple**. The tuple is defined once in `BallastConfig.spec.identityLabels` and applies to every namespace in the cluster.

--- a/charts/ballast/templates/crd-upgrade-hook.yaml
+++ b/charts/ballast/templates/crd-upgrade-hook.yaml
@@ -1,0 +1,99 @@
+{{- if .Values.crds.upgradeHook.enabled }}
+{{/*
+Helm's crds/ directory is install-only: `helm upgrade` never touches it, so CRD
+changes would silently not apply. This hook runs `ballastd apply-crds` before
+every install and upgrade, server-side-applying the CRD manifests baked into
+the operator image. Applies are atomic and idempotent (field manager
+"ballast-crd-installer", force ownership), so re-runs and manual invocations
+are safe. pre-install is included so the installer's field manager owns the
+CRDs from day one rather than leaving ownership with the initial Helm install.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ballast.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "ballast.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-2"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+rules:
+- apiGroups: ["apiextensions.k8s.io"]
+  resources: ["customresourcedefinitions"]
+  verbs: ["get", "list", "create", "patch", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+  labels:
+    {{- include "ballast.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "-1"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+subjects:
+- kind: ServiceAccount
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "ballast.fullname" . }}-crd-upgrade
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ballast.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-weight: "0"
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        {{- include "ballast.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: crd-upgrade
+    spec:
+      serviceAccountName: {{ include "ballast.fullname" . }}-crd-upgrade
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: apply-crds
+        image: {{ include "ballast.image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: ["apply-crds"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 32Mi
+          limits:
+            memory: 64Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+{{- end }}

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -12,6 +12,16 @@ fullnameOverride: ""
 serviceAccount:
   name: ""
 
+crds:
+  # Helm applies the chart's crds/ directory only on first install and never
+  # upgrades it, so CRD changes in newer releases would silently not reach the
+  # cluster. This hook runs `ballastd apply-crds` (a Job using the operator
+  # image) before every install and upgrade to keep the cluster's CRDs in
+  # sync. Disable only if CRDs are managed by external tooling; upgrades then
+  # require applying config/crd/bases/ by hand.
+  upgradeHook:
+    enabled: true
+
 # leaderElect enables Kubernetes leader election so only one replica runs the
 # controllers at a time. Must be true when replicaCount > 1; otherwise all
 # replicas run every controller simultaneously, causing duplicate Redis writes,

--- a/cmd/ballastd/main.go
+++ b/cmd/ballastd/main.go
@@ -23,6 +23,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrlmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -32,9 +33,11 @@ import (
 	metricsclientset "k8s.io/metrics/pkg/client/clientset/versioned"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
+	crdmanifests "github.com/tight-line/ballast/config/crd/bases"
 	"github.com/tight-line/ballast/internal/controller/metricscollector"
 	"github.com/tight-line/ballast/internal/controller/resourceadjuster"
 	"github.com/tight-line/ballast/internal/controller/workloadwatcher"
+	"github.com/tight-line/ballast/internal/crdapply"
 	"github.com/tight-line/ballast/internal/killswitch"
 	"github.com/tight-line/ballast/internal/logger"
 	appmetrics "github.com/tight-line/ballast/internal/metrics"
@@ -66,7 +69,35 @@ func init() {
 }
 
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "apply-crds" {
+		os.Exit(runApplyCRDs())
+	}
 	os.Exit(run())
+}
+
+// runApplyCRDs server-side-applies the embedded CRD manifests and exits. The
+// Helm chart runs this as a pre-install/pre-upgrade hook Job so CRD changes
+// ship with every release; Helm's crds/ directory is install-only. Safe to run
+// by hand at any time; each apply is atomic and idempotent (see crdapply).
+func runApplyCRDs() int {
+	ctrl.SetLogger(logger.New(logger.Options{Stdout: true}))
+	log := ctrl.Log.WithName("apply-crds")
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		log.Error(err, "Failed to load kubeconfig")
+		return 1
+	}
+	c, err := client.New(cfg, client.Options{})
+	if err != nil {
+		log.Error(err, "Failed to create client")
+		return 1
+	}
+	if err := crdapply.Apply(context.Background(), c, crdmanifests.FS, log); err != nil {
+		log.Error(err, "Failed to apply CRDs")
+		return 1
+	}
+	return 0
 }
 
 func run() int {

--- a/config/crd/bases/embed.go
+++ b/config/crd/bases/embed.go
@@ -1,0 +1,21 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+// Package crds embeds the generated CRD manifests so the operator binary can
+// apply them itself (`ballastd apply-crds`). Helm installs the chart's crds/
+// directory only on first install and never upgrades it; a pre-install and
+// pre-upgrade hook runs this subcommand to keep the cluster's CRDs in sync on
+// every release operation.
+package crds
+
+import "embed"
+
+// FS holds every generated CRD manifest in this directory. controller-gen
+// regenerates the *.yaml files in place (make manifests), so the embedded
+// copies are always current at build time.
+//
+//go:embed *.yaml
+var FS embed.FS

--- a/internal/crdapply/apply.go
+++ b/internal/crdapply/apply.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+// Package crdapply server-side-applies the operator's embedded CRD manifests.
+// It backs the `ballastd apply-crds` subcommand, which the Helm chart runs as
+// a pre-install/pre-upgrade hook so CRD changes ship with every release
+// (Helm's crds/ directory is install-only and never upgraded).
+package crdapply
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/yaml"
+)
+
+// FieldManager is the server-side-apply field manager that owns the CRD specs.
+// Every apply-crds run uses the same manager, so repeated or concurrent runs
+// never conflict with each other; ForceOwnership reclaims fields from any
+// other manager (a manual `kubectl apply`, the original Helm install).
+const FieldManager = "ballast-crd-installer"
+
+// Apply server-side-applies every *.yaml manifest in fsys, forcing ownership
+// of the fields each manifest declares. Each apply is one atomic API request
+// and the operation is idempotent, so no locking is needed: the safety comes
+// from SSA semantics, not from assumptions about who invokes it or how often.
+// Non-CRD manifests are rejected so a stray file cannot grant this command a
+// side door to apply arbitrary objects.
+func Apply(ctx context.Context, c client.Client, fsys fs.FS, log logr.Logger) error {
+	names, err := fs.Glob(fsys, "*.yaml")
+	if err != nil { // coverage:ignore - the glob pattern is constant and valid
+		return fmt.Errorf("globbing CRD manifests: %w", err)
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("no CRD manifests found")
+	}
+	for _, name := range names {
+		data, err := fs.ReadFile(fsys, name)
+		if err != nil { // coverage:ignore - reads from an embedded FS cannot fail
+			return fmt.Errorf("reading %s: %w", name, err)
+		}
+		// Unstructured (not the typed CRD struct) so the apply declares exactly
+		// the fields present in the manifest: a typed round-trip would add
+		// zero-valued fields (creationTimestamp, status) to the patch and this
+		// manager would take ownership of fields the manifest never mentions.
+		var obj unstructured.Unstructured
+		if err := yaml.Unmarshal(data, &obj.Object); err != nil {
+			return fmt.Errorf("parsing %s: %w", name, err)
+		}
+		if obj.GetKind() != "CustomResourceDefinition" {
+			return fmt.Errorf("%s: expected a CustomResourceDefinition, got %q", name, obj.GetKind())
+		}
+		applyCfg := client.ApplyConfigurationFromUnstructured(&obj)
+		if err := c.Apply(ctx, applyCfg, client.ForceOwnership, client.FieldOwner(FieldManager)); err != nil {
+			return fmt.Errorf("applying %s: %w", obj.GetName(), err)
+		}
+		log.Info("applied CRD", "name", obj.GetName())
+	}
+	return nil
+}

--- a/internal/crdapply/apply_test.go
+++ b/internal/crdapply/apply_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package crdapply_test
+
+import (
+	"context"
+	"errors"
+	"slices"
+	"strings"
+	"testing"
+	"testing/fstest"
+
+	"github.com/go-logr/logr"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	crdmanifests "github.com/tight-line/ballast/config/crd/bases"
+	"github.com/tight-line/ballast/internal/crdapply"
+)
+
+// newEnvtestClient starts a bare envtest control plane (no CRDs pre-installed,
+// unlike the controller suites) and returns a client against it.
+func newEnvtestClient(t *testing.T) client.Client {
+	t.Helper()
+	testEnv := &envtest.Environment{}
+	cfg, err := testEnv.Start()
+	if err != nil {
+		t.Fatalf("start envtest: %v", err)
+	}
+	t.Cleanup(func() { _ = testEnv.Stop() })
+
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add apiextensions to scheme: %v", err)
+	}
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return c
+}
+
+func TestApply_InstallsAndUpgradesCRDs(t *testing.T) {
+	ctx := context.Background()
+	c := newEnvtestClient(t)
+
+	// First apply: creates every embedded CRD on the virgin control plane.
+	if err := crdapply.Apply(ctx, c, crdmanifests.FS, logr.Discard()); err != nil {
+		t.Fatalf("initial Apply: %v", err)
+	}
+
+	var crd apiextensionsv1.CustomResourceDefinition
+	key := types.NamespacedName{Name: "workloadprofiles.ballast.tightlinesoftware.com"}
+	if err := c.Get(ctx, key, &crd); err != nil {
+		t.Fatalf("get workloadprofiles CRD: %v", err)
+	}
+
+	// The applied schema is current: the State printer column exists (the
+	// exact field Helm's install-only crds/ handling failed to deliver).
+	var cols []string
+	for _, col := range crd.Spec.Versions[0].AdditionalPrinterColumns {
+		cols = append(cols, col.Name)
+	}
+	if !slices.Contains(cols, "State") {
+		t.Errorf("printer columns = %v, want State present", cols)
+	}
+
+	// Ownership: the spec is managed by our field manager.
+	var managers []string
+	for _, mf := range crd.ManagedFields {
+		managers = append(managers, mf.Manager)
+	}
+	if !slices.Contains(managers, crdapply.FieldManager) {
+		t.Errorf("field managers = %v, want %s present", managers, crdapply.FieldManager)
+	}
+
+	// Second apply: idempotent upgrade path, converges without error or
+	// spurious generation bumps.
+	genBefore := crd.Generation
+	if err := crdapply.Apply(ctx, c, crdmanifests.FS, logr.Discard()); err != nil {
+		t.Fatalf("second Apply: %v", err)
+	}
+	if err := c.Get(ctx, key, &crd); err != nil {
+		t.Fatalf("re-get workloadprofiles CRD: %v", err)
+	}
+	if crd.Generation != genBefore {
+		t.Errorf("generation changed on no-op re-apply: %d -> %d", genBefore, crd.Generation)
+	}
+}
+
+func TestApply_RejectsBadInput(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		fsys    fstest.MapFS
+		wantErr string
+	}{
+		{
+			name:    "empty FS",
+			fsys:    fstest.MapFS{},
+			wantErr: "no CRD manifests",
+		},
+		{
+			name: "malformed yaml",
+			fsys: fstest.MapFS{
+				"bad.yaml": &fstest.MapFile{Data: []byte("{{ not yaml")},
+			},
+			wantErr: "parsing bad.yaml",
+		},
+		{
+			name: "not a CRD",
+			fsys: fstest.MapFS{
+				"sneaky.yaml": &fstest.MapFile{Data: []byte(
+					"apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: sneaky\n")},
+			},
+			wantErr: "expected a CustomResourceDefinition",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// No API calls happen before validation fails, so no client is needed.
+			err := crdapply.Apply(ctx, nil, tt.fsys, logr.Discard())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Apply error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestApply_SurfacesApplyErrors(t *testing.T) {
+	ctx := context.Background()
+	wantErr := errors.New("apiserver on fire")
+	c := fake.NewClientBuilder().
+		WithInterceptorFuncs(interceptor.Funcs{
+			Apply: func(context.Context, client.WithWatch, runtime.ApplyConfiguration, ...client.ApplyOption) error {
+				return wantErr
+			},
+		}).
+		Build()
+
+	err := crdapply.Apply(ctx, c, crdmanifests.FS, logr.Discard())
+	if !errors.Is(err, wantErr) {
+		t.Errorf("Apply error = %v, want wrapping %v", err, wantErr)
+	}
+}


### PR DESCRIPTION
## Problem

Helm installs the chart's `crds/` directory only on first install and never upgrades it, so every CRD change since a cluster's initial install has been silently skipped. First visible symptom: after upgrading to 0.3.2, `kubectl get workloadprofiles` still showed the old columns because the cluster's CRD never got the `STATE` printer column or the `state` field. The workaround was a manual `kubectl apply --server-side --force-conflicts` of `config/crd/bases/`.

## Fix

A pre-install/pre-upgrade hook Job runs `ballastd apply-crds`, a new operator subcommand that server-side-applies the CRD manifests embedded in the image at build time (`go:embed` of `config/crd/bases/*.yaml`, so they are always current per release).

**Safety model** (design discussion from review): the subcommand carries no locking and needs none.

- Helm provides *ordering*: the hook completes before the new operator Deployment applies, and Helm's pending-operation check serializes operations per release.
- Server-side apply provides *safety*: each apply is one atomic API request under field manager `ballast-crd-installer` with forced ownership. Re-runs, concurrent runs, and manual invocations all converge; same-manager applies never conflict with each other, and `ForceOwnership` deterministically reclaims fields from other managers (a manual `kubectl apply`, the original Helm install).
- Running on `pre-install` too means the installer's field manager owns the CRD fields from day one, so nobody hits the SSA ownership conflict that the manual workaround did.
- Non-CRD manifests are rejected, so the hook's CRD-scoped RBAC cannot be used as a side door to apply arbitrary objects.

**Why the `crds/` directory stays:** Helm validates templated resources against cluster discovery *before* hooks run, and this chart templates CRs of its own types (default `ClusterResourcePolicy`, `BallastConfig`). On a virgin cluster those kinds must already exist at validation time, which only the `crds/` directory can guarantee. So: `crds/` bootstraps the first install, the hook keeps everything current thereafter.

**Escape hatch:** `crds.upgradeHook.enabled: false` for clusters where external tooling manages CRDs; upgrades then require applying `config/crd/bases/` by hand. Note the hook requires a Helm-lifecycle executor (helm CLI, Flux helm-controller, Argo CD's hook translation); pipelines that `helm template | kubectl apply` should disable it and apply CRDs as a pipeline step.

## Testing

- envtest against a bare control plane (no pre-installed CRDs): first `Apply` creates all CRDs and the `State` printer column is present; field manager verified; second `Apply` is a no-op (generation unchanged)
- Input validation: empty FS, malformed YAML, non-CRD manifest all rejected with clear errors; apply errors surface wrapped (interceptor fake)
- `helm lint` passes and the hook renders; `make lint`: 0 issues; `make test-coverage-check`: passed at 76.8%
- Not yet exercised against a real `helm upgrade` end-to-end; the 0.3.2→next upgrade on the dev cluster is the natural live test, and success looks like: hook Job completes, then `kubectl get crd workloadprofiles... -o jsonpath='{.metadata.managedFields[*].manager}'` includes `ballast-crd-installer`