### PR TITLE
feat: apply-side metrics (apply.applied, apply.skipped) and richer resize.skipped attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New `ballast.apply.applied` and `ballast.apply.skipped` metrics.** `ballast.apply.applied` counts admission-time mutations that actually changed a pod's container resource requests or limits, carrying the same `profile`/`policy`/`namespace` attributes as `ballast.resize.applied` so dashboards can chart apply and resize activity side by side. Previously the only apply-side signal was `ballast.webhook.mutations{result="mutated"}`, which also counts patches that merely stamp annotations (such as the policy-ref) without touching resources, so "the webhook ran" and "resources were applied" were indistinguishable. `ballast.apply.skipped` counts admissions where the pod requested apply but nothing changed, with a `reason` attribute: `no_profile` (no WorkloadProfile exists yet for the workload's identity tuple), `not_ready` (profile exists but is below its history threshold), `no_change` (profile is ready but no container matched a recommendation), or `dry_run`. In particular, `no_profile` and `not_ready` (workloads that want recommendations but are not getting them yet) were previously invisible, folded into `ballast.webhook.mutations{result="skipped"}` together with pods that never requested apply. Exactly one of `apply.applied` / `apply.skipped` is recorded per admission that requests apply and finds its profile.
+
+### Changed
+
+- **`ballast.resize.skipped` now carries `policy` and `namespace` attributes**, matching `ballast.resize.applied`, `ballast.resize.failed`, and the new apply metrics. Both are empty for profile-level skips (`kill_switch`, `not_ready`, `no_policy`), which are not scoped to a single pod.
+
 ## [0.3.3] - 2026-07-02
 
 ### Fixed

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -96,13 +96,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	if r.ks.IsActive() {
 		log.Info("kill switch active, skipping resize",
 			"kill_switch", true, "kill_switch_reason", r.ks.Reason(), "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "kill_switch", pid)
+		r.rec.ResizeSkipped(ctx, "kill_switch", pid, "", "")
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
 	if !profile.Status.MeetsThreshold {
 		log.V(1).Info("profile does not meet threshold, skipping resize", "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "not_ready", pid)
+		r.rec.ResizeSkipped(ctx, "not_ready", pid, "", "")
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
@@ -112,7 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if resolved == nil {
 		log.Info("no policy matches profile, skipping resize", "profile", profile.Name)
-		r.rec.ResizeSkipped(ctx, "no_policy", pid)
+		r.rec.ResizeSkipped(ctx, "no_policy", pid, "", "")
 		return ctrl.Result{RequeueAfter: defaultResizeInterval}, nil
 	}
 
@@ -171,7 +171,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 	if last, ok := pod.Annotations[AnnotationLastResize]; ok {
 		if t, err := time.Parse(time.RFC3339, last); err == nil && time.Since(t) < interval {
 			log.V(1).Info("resize cooldown active, skipping", "pod", pod.Name, "namespace", pod.Namespace, "next_resize", t.Add(interval))
-			r.rec.ResizeSkipped(ctx, "cooldown", pid)
+			r.rec.ResizeSkipped(ctx, "cooldown", pid, policyName, pod.Namespace)
 			return nil
 		}
 	}
@@ -179,7 +179,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 	recsByName := containerRecsByName(profile)
 	adjustments := computeAdjustments(pod, recsByName, behaviors)
 	if len(adjustments) == 0 {
-		r.rec.ResizeSkipped(ctx, "no_drift", pid)
+		r.rec.ResizeSkipped(ctx, "no_drift", pid, policyName, pod.Namespace)
 		return nil
 	}
 
@@ -187,7 +187,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 
 	if r.dryRunResize {
 		log.Info("dry-run: would resize pod", append(logFields, "dry_run", true)...)
-		r.rec.ResizeSkipped(ctx, "dry_run", pid)
+		r.rec.ResizeSkipped(ctx, "dry_run", pid, policyName, pod.Namespace)
 		return nil
 	}
 

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -137,7 +137,9 @@ func TestRecorder_NilSafe(t *testing.T) {
 	rec.WorkloadProfilePurged(ctx, id)
 	rec.ResizeApplied(ctx, id, "policy", "default")
 	rec.ResizeFailed(ctx, id, "policy", "default")
-	rec.ResizeSkipped(ctx, "cooldown", id)
+	rec.ResizeSkipped(ctx, "cooldown", id, "policy", "default")
+	rec.ApplyApplied(ctx, id, "policy", "default")
+	rec.ApplySkipped(ctx, "not_ready", id, "", "default")
 	rec.WebhookMutation(ctx, "mutated", "default", id)
 	rec.KillSwitchTransition(ctx, "activated")
 	rec.SetKillSwitchActive(true, "test")
@@ -275,11 +277,50 @@ func TestRecorder_ResizeSkipped(t *testing.T) {
 	rec, reg := newTestRecorder(t)
 	ctx := context.Background()
 
-	rec.ResizeSkipped(ctx, "cooldown", metrics.ProfileID{Name: "frontend--web"})
+	rec.ResizeSkipped(ctx, "cooldown", metrics.ProfileID{Name: "frontend--web"}, "default", "staging")
 
 	got := gatherCounter(t, reg, "ballast_resize_skipped_total")
 	if got != 1 {
 		t.Errorf("ballast_resize_skipped_total = %v, want 1", got)
+	}
+	ls := firstLabels(t, reg, "ballast_resize_skipped_total")
+	if ls["reason"] != "cooldown" || ls["policy"] != "default" || ls["namespace"] != "staging" {
+		t.Errorf("reason/policy/namespace attrs = %q/%q/%q", ls["reason"], ls["policy"], ls["namespace"])
+	}
+}
+
+func TestRecorder_ApplySkipped(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+	ctx := context.Background()
+
+	rec.ApplySkipped(ctx, "not_ready", metrics.ProfileID{Name: "frontend--web"}, "", "staging")
+
+	got := gatherCounter(t, reg, "ballast_apply_skipped_total")
+	if got != 1 {
+		t.Errorf("ballast_apply_skipped_total = %v, want 1", got)
+	}
+	ls := firstLabels(t, reg, "ballast_apply_skipped_total")
+	if ls["reason"] != "not_ready" || ls["policy"] != "" || ls["namespace"] != "staging" {
+		t.Errorf("reason/policy/namespace attrs = %q/%q/%q", ls["reason"], ls["policy"], ls["namespace"])
+	}
+	if ls["profile"] != "frontend--web" {
+		t.Errorf("profile attr = %q, want frontend--web", ls["profile"])
+	}
+}
+
+func TestRecorder_ApplyApplied(t *testing.T) {
+	rec, reg := newTestRecorder(t)
+	ctx := context.Background()
+
+	rec.ApplyApplied(ctx, metrics.ProfileID{Name: "frontend--web"}, "default", "staging")
+
+	got := gatherCounter(t, reg, "ballast_apply_applied_total")
+	if got != 1 {
+		t.Errorf("ballast_apply_applied_total = %v, want 1", got)
+	}
+	ls := firstLabels(t, reg, "ballast_apply_applied_total")
+	if ls["profile"] != "frontend--web" || ls["policy"] != "default" || ls["namespace"] != "staging" {
+		t.Errorf("profile/policy/namespace attrs = %q/%q/%q", ls["profile"], ls["policy"], ls["namespace"])
 	}
 }
 

--- a/internal/metrics/recorder.go
+++ b/internal/metrics/recorder.go
@@ -51,6 +51,8 @@ type Recorder struct {
 	resizeApplied           metric.Int64Counter
 	resizeFailed            metric.Int64Counter
 	resizeSkipped           metric.Int64Counter
+	applyApplied            metric.Int64Counter
+	applySkipped            metric.Int64Counter
 	webhookMutations        metric.Int64Counter
 	killSwitchTransitions   metric.Int64Counter
 
@@ -95,6 +97,10 @@ func NewRecorder(provider metric.MeterProvider) (*Recorder, error) {
 		"In-place resize operations that failed")
 	r.resizeSkipped = counter("ballast.resize.skipped",
 		"Resize evaluations skipped before issuing a patch")
+	r.applyApplied = counter("ballast.apply.applied",
+		"Admission-time mutations that changed container resource requests/limits")
+	r.applySkipped = counter("ballast.apply.skipped",
+		"Admission-time apply evaluations that changed nothing, by reason")
 	r.webhookMutations = counter("ballast.webhook.mutations",
 		"Pod admission webhook invocations and their outcomes")
 	r.killSwitchTransitions = counter("ballast.kill_switch.transitions",
@@ -293,12 +299,49 @@ func (r *Recorder) ResizeFailed(ctx context.Context, id ProfileID, policy, names
 
 // ResizeSkipped records a resize evaluation that was skipped without issuing a patch.
 // reason is one of: cooldown, no_drift, kill_switch, not_ready, no_policy, dry_run.
-func (r *Recorder) ResizeSkipped(ctx context.Context, reason string, id ProfileID) {
+// policy and namespace are empty for profile-level skips (kill_switch, not_ready,
+// no_policy), which are not scoped to a single pod.
+func (r *Recorder) ResizeSkipped(ctx context.Context, reason string, id ProfileID, policy, namespace string) {
 	if r == nil {
 		return
 	}
-	attrs := append(profileAttrs(id), attribute.String("reason", reason))
+	attrs := append(profileAttrs(id),
+		attribute.String("reason", reason),
+		attribute.String("policy", policy),
+		attribute.String("namespace", namespace),
+	)
 	r.resizeSkipped.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// ApplyApplied records an admission-time mutation that changed at least one
+// container's resource requests/limits. This is narrower than a "mutated"
+// WebhookMutation, which also counts patches that only stamp annotations
+// (e.g. the policy-ref) without touching resources.
+func (r *Recorder) ApplyApplied(ctx context.Context, id ProfileID, policy, namespace string) {
+	if r == nil {
+		return
+	}
+	attrs := append(profileAttrs(id),
+		attribute.String("policy", policy),
+		attribute.String("namespace", namespace),
+	)
+	r.applyApplied.Add(ctx, 1, metric.WithAttributes(attrs...))
+}
+
+// ApplySkipped records an admission evaluation for a pod that requested apply but
+// where nothing was changed. reason is one of: no_profile, not_ready, no_change,
+// dry_run. policy is empty when the skip happens before policy resolution
+// (no_profile, not_ready).
+func (r *Recorder) ApplySkipped(ctx context.Context, reason string, id ProfileID, policy, namespace string) {
+	if r == nil {
+		return
+	}
+	attrs := append(profileAttrs(id),
+		attribute.String("reason", reason),
+		attribute.String("policy", policy),
+		attribute.String("namespace", namespace),
+	)
+	r.applySkipped.Add(ctx, 1, metric.WithAttributes(attrs...))
 }
 
 // WebhookMutation records a pod admission webhook invocation.

--- a/internal/webhook/pod_mutator.go
+++ b/internal/webhook/pod_mutator.go
@@ -75,35 +75,30 @@ func (m *PodMutator) Handle(ctx context.Context, req admission.Request) admissio
 		return admission.Denied(err.Error())
 	}
 
-	profile, ok, err := m.resolveApplyProfile(ctx, &pod)
+	if !wantsApply(pod.Annotations) {
+		m.rec.WebhookMutation(ctx, "skipped", req.Namespace, metrics.ProfileID{})
+		return admission.Allowed("apply not requested")
+	}
+
+	profile, err := m.lookupProfile(ctx, &pod)
 	if err != nil {
 		log.V(1).Info("profile resolution error, allowing without mutation", "err", err)
 		m.rec.WebhookMutation(ctx, "not_available", req.Namespace, metrics.ProfileID{})
 		return admission.Allowed("profile not available")
 	}
-	if !ok {
+	if profile == nil {
+		m.rec.ApplySkipped(ctx, "no_profile", metrics.ProfileID{}, "", pod.Namespace)
 		m.rec.WebhookMutation(ctx, "skipped", req.Namespace, metrics.ProfileID{})
-		return admission.Allowed("apply not active or profile not ready")
+		return admission.Allowed("no profile for workload yet")
+	}
+	if !profile.Status.MeetsThreshold {
+		pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
+		m.rec.ApplySkipped(ctx, "not_ready", pid, "", pod.Namespace)
+		m.rec.WebhookMutation(ctx, "skipped", req.Namespace, metrics.ProfileID{})
+		return admission.Allowed("profile not ready")
 	}
 
 	return m.mutate(ctx, &pod, profile)
-}
-
-// resolveApplyProfile returns the WorkloadProfile to use for patching, and true if apply
-// should proceed. Returns (nil, false, nil) when apply is not requested or the profile is
-// not ready — both are normal non-error states.
-func (m *PodMutator) resolveApplyProfile(ctx context.Context, pod *corev1.Pod) (*ballastv1.WorkloadProfile, bool, error) {
-	if !wantsApply(pod.Annotations) {
-		return nil, false, nil
-	}
-	p, err := m.lookupProfile(ctx, pod)
-	if err != nil {
-		return nil, false, err
-	}
-	if p == nil || !p.Status.MeetsThreshold {
-		return nil, false, nil
-	}
-	return p, true, nil
 }
 
 // wantsApply reports whether the pod carries any annotation that requests resource application.
@@ -124,12 +119,24 @@ func (m *PodMutator) mutate(ctx context.Context, pod *corev1.Pod, profile *balla
 	log := ctrl.Log.WithName("webhook")
 
 	modifiedPod := pod.DeepCopy()
-	m.stampPolicyRef(ctx, pod, modifiedPod)
+	policyRef := m.stampPolicyRef(ctx, pod, modifiedPod)
 
 	applied := applyRecommendations(modifiedPod, profile)
 	log.Info("applying resource recommendations", "dry_run", m.dryRunApply, "containers", applied)
 
 	pid := metrics.ProfileID{Name: profile.Name, Labels: profile.Status.TupleLabels}
+
+	// Exactly one apply.* outcome per admission that requested apply: no_change
+	// wins over dry_run (nothing would have changed either way), and applied is
+	// recorded only when a real patch changed resources.
+	switch {
+	case len(applied) == 0:
+		m.rec.ApplySkipped(ctx, "no_change", pid, policyRef, pod.Namespace)
+	case m.dryRunApply:
+		m.rec.ApplySkipped(ctx, "dry_run", pid, policyRef, pod.Namespace)
+	default:
+		m.rec.ApplyApplied(ctx, pid, policyRef, pod.Namespace)
+	}
 
 	if m.dryRunApply {
 		m.rec.WebhookMutation(ctx, "dry_run", pod.Namespace, pid)
@@ -140,9 +147,10 @@ func (m *PodMutator) mutate(ctx context.Context, pod *corev1.Pod, profile *balla
 	return patchResponse(pod, modifiedPod)
 }
 
-// stampPolicyRef resolves the active policy and stamps its name onto modifiedPod.
-// Policy resolution failures are non-fatal — the admission proceeds without a policy-ref.
-func (m *PodMutator) stampPolicyRef(ctx context.Context, pod, modifiedPod *corev1.Pod) {
+// stampPolicyRef resolves the active policy and stamps its name onto modifiedPod,
+// returning the stamped ref ("" when no policy resolved). Policy resolution
+// failures are non-fatal — the admission proceeds without a policy-ref.
+func (m *PodMutator) stampPolicyRef(ctx context.Context, pod, modifiedPod *corev1.Pod) string {
 	resolved, err := m.resolver.Resolve(ctx, policy.Input{
 		Namespace:   pod.Namespace,
 		OwnerKind:   directOwnerKind(pod),
@@ -151,15 +159,17 @@ func (m *PodMutator) stampPolicyRef(ctx context.Context, pod, modifiedPod *corev
 	})
 	if err != nil { // coverage:ignore - transient API error listing policy objects
 		ctrl.Log.WithName("webhook").V(1).Info("policy resolution error, skipping policy-ref", "err", err)
-		return
+		return ""
 	}
-	if resolved != nil {
-		ref := resolved.Name
-		if resolved.Namespaced {
-			ref = pod.Namespace + "/" + resolved.Name
-		}
-		modifiedPod.Annotations[validation.AnnotationPolicyRef] = ref
+	if resolved == nil {
+		return ""
 	}
+	ref := resolved.Name
+	if resolved.Namespaced {
+		ref = pod.Namespace + "/" + resolved.Name
+	}
+	modifiedPod.Annotations[validation.AnnotationPolicyRef] = ref
+	return ref
 }
 
 // lookupProfile resolves the WorkloadProfile for the given pod.

--- a/internal/webhook/pod_mutator_test.go
+++ b/internal/webhook/pod_mutator_test.go
@@ -13,6 +13,9 @@ import (
 	"strings"
 	"testing"
 
+	promclient "github.com/prometheus/client_golang/prometheus"
+	promexporter "go.opentelemetry.io/otel/exporters/prometheus"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -28,6 +31,7 @@ import (
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
 	"github.com/tight-line/ballast/internal/killswitch"
+	"github.com/tight-line/ballast/internal/metrics"
 	"github.com/tight-line/ballast/internal/validation"
 	"github.com/tight-line/ballast/internal/webhook"
 )
@@ -134,6 +138,47 @@ func testPod(name string, anns map[string]string) *corev1.Pod {
 			},
 		},
 	}
+}
+
+// newMetricsRecorder returns a Recorder backed by a Prometheus registry so tests
+// can assert on the series the webhook records.
+func newMetricsRecorder(t *testing.T) (*metrics.Recorder, *promclient.Registry) {
+	t.Helper()
+	reg := promclient.NewRegistry()
+	exp, err := promexporter.New(promexporter.WithRegisterer(reg))
+	if err != nil {
+		t.Fatalf("creating prometheus exporter: %v", err)
+	}
+	provider := sdkmetric.NewMeterProvider(sdkmetric.WithReader(exp))
+	t.Cleanup(func() { _ = provider.Shutdown(context.Background()) })
+	rec, err := metrics.NewRecorder(provider)
+	if err != nil {
+		t.Fatalf("creating recorder: %v", err)
+	}
+	return rec, reg
+}
+
+// counterSeries returns the value and labels of the named counter's first series,
+// or (0, nil) when the metric has no series.
+func counterSeries(t *testing.T, reg *promclient.Registry, name string) (value float64, labels map[string]string) {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := make(map[string]string, len(m.GetLabel()))
+			for _, lp := range m.GetLabel() {
+				labels[lp.GetName()] = lp.GetValue()
+			}
+			return m.GetCounter().GetValue(), labels
+		}
+	}
+	return 0, nil
 }
 
 func hasResourcePatch(resp admission.Response) bool {
@@ -436,6 +481,150 @@ func TestPodMutator_UnmatchedContainer(t *testing.T) {
 	}
 	if !hasResourcePatch(resp) {
 		t.Errorf("expected patches for matched container, got none")
+	}
+}
+
+// TestPodMutator_ApplyAppliedMetric asserts a mutation that changes container
+// resources records ballast.apply.applied with profile, policy, and namespace
+// attributes.
+func TestPodMutator_ApplyAppliedMetric(t *testing.T) {
+	policy := &ballastv1.ClusterResourcePolicy{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-policy"},
+		Spec:       ballastv1.ClusterResourcePolicySpec{},
+	}
+	fc := newFakeClient(defaultBallastConfig(), readyProfile(), policy)
+	rec, reg := newMetricsRecorder(t)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false, rec)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+
+	got, labels := counterSeries(t, reg, "ballast_apply_applied_total")
+	if got != 1 {
+		t.Fatalf("ballast_apply_applied_total = %v, want 1", got)
+	}
+	if labels["profile"] != "web" || labels["policy"] != "default-policy" || labels["namespace"] != "default" {
+		t.Errorf("profile/policy/namespace attrs = %q/%q/%q",
+			labels["profile"], labels["policy"], labels["namespace"])
+	}
+}
+
+// TestPodMutator_ApplyAppliedMetric_AnnotationOnlyMutation asserts a mutation whose
+// patch touches no container resources (no container matches the profile) reports
+// result=mutated but does not record ballast.apply.applied.
+func TestPodMutator_ApplyAppliedMetric_AnnotationOnlyMutation(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	rec, reg := newMetricsRecorder(t)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false, rec)
+
+	// The pod's only container is absent from the profile, so the patch carries
+	// no resource changes.
+	pod := testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})
+	pod.Spec.Containers = []corev1.Container{{Name: "sidecar", Image: "envoy"}}
+
+	resp := m.Handle(context.Background(), makeRequest(pod))
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+
+	// Prove the mutate path ran: the webhook counted the invocation as mutated.
+	mutations, mutationLabels := counterSeries(t, reg, "ballast_webhook_mutations_total")
+	if mutations != 1 || mutationLabels["result"] != "mutated" {
+		t.Fatalf("ballast_webhook_mutations_total = %v (result=%q), want 1 with result=mutated",
+			mutations, mutationLabels["result"])
+	}
+	if got, _ := counterSeries(t, reg, "ballast_apply_applied_total"); got != 0 {
+		t.Errorf("ballast_apply_applied_total = %v, want 0 when no resources changed", got)
+	}
+	skipped, skipLabels := counterSeries(t, reg, "ballast_apply_skipped_total")
+	if skipped != 1 || skipLabels["reason"] != "no_change" {
+		t.Errorf("ballast_apply_skipped_total = %v (reason=%q), want 1 with reason=no_change",
+			skipped, skipLabels["reason"])
+	}
+}
+
+// TestPodMutator_ApplySkippedMetric_NotReady asserts a pod that requests apply
+// against a below-threshold profile records ballast.apply.skipped{reason=not_ready}
+// carrying the profile attributes.
+func TestPodMutator_ApplySkippedMetric_NotReady(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), notReadyProfile())
+	rec, reg := newMetricsRecorder(t)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false, rec)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+
+	got, labels := counterSeries(t, reg, "ballast_apply_skipped_total")
+	if got != 1 || labels["reason"] != "not_ready" {
+		t.Fatalf("ballast_apply_skipped_total = %v (reason=%q), want 1 with reason=not_ready",
+			got, labels["reason"])
+	}
+	if labels["profile"] != "web" || labels["namespace"] != "default" {
+		t.Errorf("profile/namespace attrs = %q/%q", labels["profile"], labels["namespace"])
+	}
+}
+
+// TestPodMutator_ApplySkippedMetric_NoProfile asserts a pod that requests apply
+// before any profile exists records ballast.apply.skipped{reason=no_profile}
+// without profile attributes.
+func TestPodMutator_ApplySkippedMetric_NoProfile(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig())
+	rec, reg := newMetricsRecorder(t)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), false, rec)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+
+	got, labels := counterSeries(t, reg, "ballast_apply_skipped_total")
+	if got != 1 || labels["reason"] != "no_profile" {
+		t.Fatalf("ballast_apply_skipped_total = %v (reason=%q), want 1 with reason=no_profile",
+			got, labels["reason"])
+	}
+	if _, ok := labels["profile"]; ok {
+		t.Errorf("profile attr present on no_profile skip: %q", labels["profile"])
+	}
+}
+
+// TestPodMutator_ApplySkippedMetric_DryRun asserts a suppressed apply that would
+// have changed resources records reason=dry_run and no apply.applied.
+func TestPodMutator_ApplySkippedMetric_DryRun(t *testing.T) {
+	fc := newFakeClient(defaultBallastConfig(), readyProfile())
+	rec, reg := newMetricsRecorder(t)
+	m := webhook.NewPodMutator(fc, inactiveKS(t), true /* dryRunApply */, rec)
+
+	resp := m.Handle(context.Background(), makeRequest(testPod("p", map[string]string{
+		validation.AnnotationMeasure: "true",
+		validation.AnnotationApply:   "true",
+	})))
+	if !resp.Allowed {
+		t.Fatalf("expected Allowed, got: %s", resp.Result.Message)
+	}
+
+	got, labels := counterSeries(t, reg, "ballast_apply_skipped_total")
+	if got != 1 || labels["reason"] != "dry_run" {
+		t.Fatalf("ballast_apply_skipped_total = %v (reason=%q), want 1 with reason=dry_run",
+			got, labels["reason"])
+	}
+	if applied, _ := counterSeries(t, reg, "ballast_apply_applied_total"); applied != 0 {
+		t.Errorf("ballast_apply_applied_total = %v, want 0 in dry-run", applied)
 	}
 }
 


### PR DESCRIPTION
## Problem

The only apply-side telemetry was `ballast.webhook.mutations`. Its `result="mutated"` outcome fires for any patch, including ones that only stamp annotations (such as the policy-ref) without touching resources, so dashboards could not distinguish "the webhook ran" from "resources were actually applied". Worse, pods that requested apply but could not get it yet (no profile, or profile below threshold) were folded into `result="skipped"` together with pods that never requested apply, making "workloads waiting on recommendations" invisible.

## Changes

- **New `ballast.apply.applied` counter.** Recorded when an admission mutation changes at least one container's requests/limits. Carries `profile`/`policy`/`namespace` attributes, matching `ballast.resize.applied`, so apply and resize panels can be built identically.

- **New `ballast.apply.skipped` counter.** Recorded when a pod requested apply but nothing changed, with a `reason` attribute:

  - `no_profile`: no WorkloadProfile exists yet for the workload's identity tuple
  - `not_ready`: profile exists but is below its history threshold
  - `no_change`: profile ready but no container matched a recommendation
  - `dry_run`: apply suppressed by the dry-run flag

  Exactly one `apply.*` outcome is recorded per admission that requests apply and finds its profile (`no_change` takes precedence over `dry_run`, mirroring how resize prioritizes `no_drift`).

- **`ballast.resize.skipped` gains `policy` and `namespace` attributes**, matching the rest of the resize family. Both are empty for profile-level skips (`kill_switch`, `not_ready`, `no_policy`), which happen before any single pod or policy is in scope.

`ballast.webhook.mutations` series keep their exact prior semantics; nothing existing dashboards key on shifts meaning. In the webhook, `resolveApplyProfile` is dissolved into `Handle` so the skip reasons stay distinguishable, and `stampPolicyRef` now returns the resolved ref so the apply metrics can carry the `policy` attribute.

## Testing

- Recorder unit tests for both new counters and the enriched `resize.skipped` attributes, plus nil-recorder safety.
- Webhook tests drive each skip reason and the applied path end to end through `Handle` and assert on the recorded Prometheus series.
- `make lint`: 0 issues. `make test-coverage-check`: passed at 77.0% (webhook 96.3%, metrics 95.4%), no new `coverage:ignore`.