### PR TITLE
fix: set service.instance.id so replicas export distinct metric series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.3.5] - 2026-07-02
+### Fixed
+
+- **Metrics from multiple replicas no longer merge into one series.** The chart now sets `service.instance.id` (the pod name, via the downward API) in `OTEL_RESOURCE_ATTRIBUTES`. Previously every replica exported identical resource attributes, so backends fingerprinted all replicas' samples into a single series. For cumulative counters emitted on every replica — the webhook-path metrics `ballast.webhook.mutations`, `ballast.apply.applied`, and `ballast.apply.skipped` — the interleaved per-process counts looked like a counter resetting on every sample, inflating `rate()`/`increase()` beyond any real activity; leader-only counters got the same distortion transiently at leader handoff. Gauges such as `ballast.profiles` appeared correct in steady state but double-counted during rollouts, when `service.version` briefly made the replicas distinguishable. With per-pod identity, each replica is its own series: counter math is correct (sum of per-instance increases), and gauge queries that aggregate across replicas should deduplicate explicitly (e.g. `max by (<identity tuple>)` before summing). Dashboards that relied on replicas being indistinguishable will see per-pod series after upgrading.
 
 ### Fixed
 

--- a/charts/ballast/templates/deployment.yaml
+++ b/charts/ballast/templates/deployment.yaml
@@ -89,10 +89,18 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: OTEL_SERVICE_NAME
           value: {{ .Values.telemetry.serviceName | default "ballast" | quote }}
+        # service.instance.id distinguishes replicas in the OTLP export stream. Without
+        # it, all replicas emit identical resource attributes, the backend merges their
+        # samples into one series, and interleaved cumulative counters from the webhook
+        # path (which runs on every replica) read as constant resets, inflating rates.
         - name: OTEL_RESOURCE_ATTRIBUTES
-          value: {{ printf "service.version=%s,service.namespace=%s" .Chart.AppVersion (.Values.telemetry.serviceNamespace | default "tightlinesoftware.com") | quote }}
+          value: {{ printf "service.version=%s,service.namespace=%s,service.instance.id=$(POD_NAME)" .Chart.AppVersion (.Values.telemetry.serviceNamespace | default "tightlinesoftware.com") | quote }}
         ports:
         - name: health
           containerPort: 8081


### PR DESCRIPTION
## Problem

The chart's `OTEL_RESOURCE_ATTRIBUTES` carries only `service.version` and `service.namespace`, so every ballastd replica exports an identical resource attribute set. Metrics backends fingerprint series by the full attribute set, which merges all replicas' samples into one series. Two consequences:

- **Webhook-path counters are corrupted with `replicaCount > 1`.** `ballast.webhook.mutations`, `ballast.apply.applied`, and `ballast.apply.skipped` are emitted by every replica (the webhook is not leader-gated). Two per-process cumulative streams interleaved into one series look like a counter that resets on every sample, so `rate()`/`increase()` report inflated garbage. Leader-only counters get the same distortion transiently at leader handoff.
- **Gauges double-count during rollouts.** `ballast.profiles` looks correct in steady state (both replicas report the same truth into the same series) but doubles whenever `service.version` briefly makes the pods distinguishable, e.g. a version upgrade.

## Fix

Inject the pod name via the downward API and append `service.instance.id=$(POD_NAME)` to `OTEL_RESOURCE_ATTRIBUTES`, per OTel resource semantic conventions. Each replica now exports its own series identity:

- counters are monotonic per series, so summing per-instance increases is correct;
- gauge queries that aggregate across replicas should deduplicate explicitly (e.g. `max by (<identity tuple>)` before summing), which is the standard shape for multi-reporter gauges.

Verified with `helm template`: `POD_NAME` is defined before `OTEL_RESOURCE_ATTRIBUTES`, so kubelet env interpolation resolves it at container start.

## Note for dashboard owners

After upgrading, each pod produces its own series. Queries that `sum` across series without deduplication will see per-pod copies of gauges all the time (previously only during rollouts); use max-by-identity-then-sum for gauges and sum-of-increase for counters.

`make lint` (0 issues) and `make test-coverage-check` (77.2%) both pass.