### PR TITLE
Sync CRDs into the chart before packaging in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,17 @@ jobs:
       - name: Update Helm dependencies
         run: helm dependency update charts/ballast
 
+      # crds/ is a build artifact (gitignored since it's synced from
+      # config/crd/bases/), so a fresh checkout doesn't have it. Without this
+      # step the published package ships no CRDs and a first install on a bare
+      # cluster fails validation ("ensure CRDs are installed first") before the
+      # pre-install CRD hook ever runs. Mirrors the `helm-build` Make target,
+      # minus the Go toolchain it would pull in via `manifests`.
+      - name: Sync CRDs into the chart
+        run: |
+          mkdir -p charts/ballast/crds
+          cp config/crd/bases/*.yaml charts/ballast/crds/
+
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@a917fd15b20e8b64b94d9158ad54cd6345335584 # v1.6.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Published chart packages ship their CRDs again, restoring first install on a bare cluster.** When `charts/ballast/crds/` became a gitignored build artifact (synced from `config/crd/bases/` by `make helm-build`), the release workflow's chart job kept packaging straight from a fresh checkout — which has no `crds/` — so every published package since then contained no CRDs. On a cluster without a prior install, `helm install` (or the install leg of `helm upgrade --install`) then failed manifest validation with `ensure CRDs are installed first`: the manifest includes the chart's own `BallastConfig`/`MetricsSource`/`ClusterResourcePolicy` objects, and Helm validates it before the pre-install CRD hook (0.3.3) ever runs, so the hook cannot rescue a first install. Existing clusters never noticed because the pre-upgrade hook keeps their CRDs in sync. The release workflow now syncs `config/crd/bases/*.yaml` into the chart before packaging, and `helm-build` creates the `crds/` directory first so the Make path also works from a fresh clone. Installs from older packages need the CRDs applied by hand (`kubectl apply -f config/crd/bases/`) before the first `helm install`.
+
 ## [0.3.7] - 2026-07-02
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ CHART_DIR ?= charts/ballast
 HELM_LOCAL_EXTRA ?=
 
 helm-build: manifests ## Sync CRDs from config/crd/bases/ and download chart dependencies.
+	mkdir -p $(CHART_DIR)/crds
 	cp config/crd/bases/*.yaml $(CHART_DIR)/crds/
 	$(HELM) dependency update $(CHART_DIR)
 


### PR DESCRIPTION
## Problem

Every chart package published since crds/ became a build artifact (d399ecc, "Treat CRDs and dist/ as build artifacts, not source") ships **without CRDs**. The `release-chart` job checks out a fresh tree, runs `helm dependency update`, and hands straight to chart-releaser — but crds/ is gitignored and nothing in the job regenerates it, so `helm package` has nothing to include. Verified against the published v0.3.6 tarball: no `crds/` entries.

The consequence: a **first install on a bare cluster fails**. Helm validates the release manifest — which includes the chart's own `BallastConfig`, `MetricsSource`, and `ClusterResourcePolicy` objects — *before* executing pre-install hooks, so the `crd-upgrade` hook never gets a chance to create the CRDs and the install dies with:

```
unable to build kubernetes objects from release manifest: [resource mapping not found for
name: "ballast" ... no matches for kind "BallastConfig" ... ensure CRDs are installed first]
```

This bit us for real onboarding the corp-dev IKE cluster today; the CRDs had to be applied by hand from `config/crd/bases/` to get past it. Existing installs never notice because the pre-upgrade hook keeps their CRDs in sync.

Local `make helm-package` masks the bug: it depends on `helm-build`, which syncs `config/crd/bases/*.yaml` into the chart, and long-lived working trees still have a populated crds/ dir from before d399ecc.

## Fix

- **release.yml**: add a "Sync CRDs into the chart" step (`mkdir -p` + `cp` from `config/crd/bases/`) before chart-releaser. It mirrors `helm-build` rather than calling it, to avoid pulling the Go toolchain into the chart job via the `manifests` dependency.
- **Makefile**: `mkdir -p $(CHART_DIR)/crds` in `helm-build`, so the Make path also works from a fresh clone (`cp` with multiple sources fails when the target directory doesn't exist).

With crds/ back in the package, the intended design works end to end: `helm install` (or the install leg of `helm upgrade --install`) applies crds/ before manifest validation, and the pre-install/pre-upgrade hook owns them from then on.

## Verification

Simulated the CI path from a clean `git archive` checkout (no crds/, reproducing the bug), applied the new step, ran `helm dependency update` + `helm package`:

```
$ tar tzf dist/ballast-0.3.7.tgz | grep crds
ballast/crds/ballast.tightlinesoftware.com_ballastconfigs.yaml
ballast/crds/ballast.tightlinesoftware.com_clusterresourcepolicies.yaml
ballast/crds/ballast.tightlinesoftware.com_metricssources.yaml
ballast/crds/ballast.tightlinesoftware.com_resourcepolicies.yaml
ballast/crds/ballast.tightlinesoftware.com_workloadprofiles.yaml
```