### PR TITLE
Cap resize steps by the gap to the recommendation, not the current value

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,7 +90,7 @@ Pod CREATE ──► PodMutator (admission webhook)
                   ▼
            ResourceAdjuster (controller, WorkloadProfile events)
                   │  detects drift between current and recommended values
-                  │  caps adjustment per cycle (maxChangePerCycle)
+                  │  caps adjustment per cycle (maxChangePerCycle, % of gap)
                   └──► in-place pod resize (Kubernetes 1.35+)
 ```
 
@@ -155,7 +155,7 @@ Dry-run (`--dry-run-measure`) skips steps 5 and 10. Kill switch skips both.
 
 Triggered by `WorkloadProfile` status changes and a periodic requeue timer (`behaviors.resize.interval`, default 15 minutes). For each pod with `resize` (or `autoresize`) annotation and a ready profile:
 1. Calls `ExceedsDrift(current, recommended, thresholdPct)` per container/resource/field
-2. If drift exceeded, calls `CapChange(current, recommended, maxChangePct)` to bound the adjustment
+2. If drift exceeded, calls `CapChange(current, recommended, maxChangePct, thresholdPct)` to bound the adjustment to `maxChangePct`% of the current→recommended gap; a capped step landing within the drift threshold applies the recommendation exactly (no Zeno tail)
 3. Issues the resize patch via the pod resize subresource
 4. On failure (node pressure, infeasible): emits a Kubernetes Event and stamps `resize-blocked` annotation; retries on next cycle
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`maxChangePerCycle` now caps resize steps as a percentage of the gap to the recommendation, as documented.** The cap was computed against the current value instead of the current→recommended gap, so a badly underprovisioned workload converged backwards: tiny steps first, then exponentially larger ones (each cycle at most 1.5x the previous value with the default 50%), taking hours to correct a large gap. Steps are now capped at `maxChangePerCycle` percent of the remaining gap, so the first cycle makes the largest correction and later cycles refine it. To avoid the geometric tail never reaching the target (and parking a request just inside the drift threshold, which for the default policy could mean settling at the observed average usage with no headroom), a capped step that would land within the drift threshold of the recommendation applies the recommendation exactly; with the defaults (50% cap, 20% threshold) convergence completes in at most a few cycles from any starting point.
+
 ## [0.3.8] - 2026-07-02
 
 ### Fixed

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -157,7 +157,7 @@ spec:
             # memory.request uses resize.default = "20%"
     # a drift in ANY field exceeding its threshold independently triggers the behavior
     resize:
-      maxChangePerCycle: "50%"    # default: 50% — cap single-cycle adjustment
+      maxChangePerCycle: "50%"    # default: 50% — cap single-cycle step to this % of the current→recommended gap
       interval: "15m"             # default: 15m — how often ResourceAdjuster re-evaluates
 ```
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -418,7 +418,7 @@ Pod eviction is out of scope for Ballast — delegated to [Kubernetes Deschedule
   - Re-evaluates on `behaviors.resize.interval` timer
   - **Drift detection:** for each container/resource/field in `recommendations`, compare current pod value to recommended value; compute drift as `|current - recommended| / recommended`; look up threshold via coalesce order (`resourceThresholds -> resize.default -> thresholds.default`); trigger if drift exceeds threshold for any field
   - **Resize path (if `resize` annotation present and drift exceeds threshold):**
-    1. Cap adjustment to `maxChangePerCycle` relative to current value
+    1. Cap adjustment to `maxChangePerCycle` relative to the current→recommended gap
     2. Patch pod via `resize` subresource (`v1.Pod` resize API, Kubernetes 1.35+)
     3. On success: record in pod annotation and profile status
     4. On failure (node pressure / infeasible): emit Kubernetes Event, record blocked state in profile status, requeueAfter interval

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This catch-all policy applies to every opted-in pod in the cluster. Key design d
 - **Ephemeral storage from the kubelet Summary API.** The request is sized at p90 (the growth-skewed distribution) and the limit at `p99 * 1.2` so the kubelet evicts a genuine runaway pod before the node hits disk pressure while tolerating a normal spike above the observed peak.
 - **250 samples over 24 hours before acting.** At the 5-minute poll interval a single long-running pod accrues ~288 samples in 24h, so the 24h window — not the sample count — is the binding constraint. A high coefficient of variation (CV > 1.5) also blocks action — it means the workload is too spiky to size reliably.
 - **20% drift threshold.** A resize only fires when the current resource value deviates from the recommendation by more than 20%, avoiding churn from minor fluctuations.
-- **50% max change per cycle.** Caps how aggressively a single resize can move a value, giving workloads time to stabilize between adjustments.
+- **50% max change per cycle.** Each resize moves at most half the remaining gap between the current value and the recommendation, giving workloads time to stabilize between adjustments. The first step makes most of the correction; once a step would land within the drift threshold, the recommendation is applied exactly, so convergence completes instead of stalling just inside the threshold.
 - **Priority 0.** This is the lowest possible priority. Any `ClusterResourcePolicy` or `ResourcePolicy` with `priority > 0` wins for matched workloads, so you can override specific namespaces or workload kinds without touching this default.
 
 ### Policy presets

--- a/api/v1/clusterresourcepolicy_types.go
+++ b/api/v1/clusterresourcepolicy_types.go
@@ -163,7 +163,10 @@ type ResourceFieldThresholds struct {
 
 // ResizeConfig configures in-place pod resize behavior.
 type ResizeConfig struct {
-	// MaxChangePerCycle caps how much a single adjustment cycle can change a value.
+	// MaxChangePerCycle caps how much a single adjustment cycle can change a value,
+	// expressed as a percentage of the gap between the current and recommended
+	// values. When a capped step would land within the drift threshold of the
+	// recommendation, the recommendation is applied exactly instead.
 	// +optional
 	// +kubebuilder:default="50%"
 	MaxChangePerCycle string `json:"maxChangePerCycle,omitempty"`

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -245,7 +245,9 @@ defaultClusterResourcePolicy:
       # default is the minimum drift from the recommendation before a resize fires.
       default: "20%"
     resize:
-      # maxChangePerCycle caps how much a single adjustment can change a value.
+      # maxChangePerCycle caps a single adjustment at this percentage of the gap
+      # between the current and recommended values; a step landing within the
+      # drift threshold applies the recommendation exactly.
       maxChangePerCycle: "50%"
       # interval is how often the ResourceAdjuster re-evaluates drift.
       interval: "15m"

--- a/config/crd/bases/ballast.tightlinesoftware.com_clusterresourcepolicies.yaml
+++ b/config/crd/bases/ballast.tightlinesoftware.com_clusterresourcepolicies.yaml
@@ -60,8 +60,11 @@ spec:
                         type: string
                       maxChangePerCycle:
                         default: 50%
-                        description: MaxChangePerCycle caps how much a single adjustment
-                          cycle can change a value.
+                        description: |-
+                          MaxChangePerCycle caps how much a single adjustment cycle can change a value,
+                          expressed as a percentage of the gap between the current and recommended
+                          values. When a capped step would land within the drift threshold of the
+                          recommendation, the recommendation is applied exactly instead.
                         type: string
                     type: object
                   thresholds:

--- a/config/crd/bases/ballast.tightlinesoftware.com_resourcepolicies.yaml
+++ b/config/crd/bases/ballast.tightlinesoftware.com_resourcepolicies.yaml
@@ -59,8 +59,11 @@ spec:
                         type: string
                       maxChangePerCycle:
                         default: 50%
-                        description: MaxChangePerCycle caps how much a single adjustment
-                          cycle can change a value.
+                        description: |-
+                          MaxChangePerCycle caps how much a single adjustment cycle can change a value,
+                          expressed as a percentage of the gap between the current and recommended
+                          values. When a capped step would land within the drift threshold of the
+                          recommendation, the recommendation is applied exactly instead.
                         type: string
                     type: object
                   thresholds:

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -338,7 +338,7 @@ func evaluateField(
 	if err != nil || !ExceedsDrift(current, recommended, threshold) {
 		return false
 	}
-	dst[resName] = CapChange(current, recommended, maxChange)
+	dst[resName] = CapChange(current, recommended, maxChange, threshold)
 	return true
 }
 
@@ -378,8 +378,11 @@ func resolveMaxChangePercent(behaviors ballastv1.BehaviorConfig) float64 {
 // exceedsDrift returns true when |recommended - current| / current > threshold%.
 // If current is zero and recommended is nonzero, drift is treated as infinite (always resize).
 func ExceedsDrift(current, recommended resource.Quantity, thresholdPct float64) bool {
-	cur := current.AsApproximateFloat64()
-	rec := recommended.AsApproximateFloat64()
+	return exceedsDriftFloat(current.AsApproximateFloat64(), recommended.AsApproximateFloat64(), thresholdPct)
+}
+
+// exceedsDriftFloat is ExceedsDrift on raw float values.
+func exceedsDriftFloat(cur, rec, thresholdPct float64) bool {
 	if cur == 0 {
 		return rec > 0
 	}
@@ -390,9 +393,12 @@ func ExceedsDrift(current, recommended resource.Quantity, thresholdPct float64) 
 	return drift > thresholdPct/100.0
 }
 
-// capChange applies maxChangePerCycle: if the move from current to recommended
-// exceeds maxChangePct% of current, cap it at that fraction toward recommended.
-func CapChange(current, recommended resource.Quantity, maxChangePct float64) resource.Quantity {
+// CapChange applies maxChangePerCycle: a single cycle moves at most
+// maxChangePct% of the gap between current and recommended. When the capped
+// step would land within thresholdPct of the recommendation (so the next
+// cycle's drift check would not fire), the recommendation is applied exactly
+// instead of parking the value just inside the drift band forever.
+func CapChange(current, recommended resource.Quantity, maxChangePct, thresholdPct float64) resource.Quantity {
 	cur := current.AsApproximateFloat64()
 	rec := recommended.AsApproximateFloat64()
 
@@ -400,20 +406,20 @@ func CapChange(current, recommended resource.Quantity, maxChangePct float64) res
 		return recommended
 	}
 
-	maxDelta := cur * (maxChangePct / 100.0)
-	delta := rec - cur
-	if delta < 0 {
-		delta = -delta
+	gap := rec - cur
+	if gap < 0 {
+		gap = -gap
 	}
-	if delta <= maxDelta {
-		return recommended
-	}
+	step := gap * (maxChangePct / 100.0)
 
 	var capped float64
 	if rec > cur {
-		capped = cur + maxDelta
+		capped = cur + step
 	} else {
-		capped = cur - maxDelta
+		capped = cur - step
+	}
+	if !exceedsDriftFloat(capped, rec, thresholdPct) {
+		return recommended
 	}
 
 	if strings.HasSuffix(recommended.String(), "m") {

--- a/internal/controller/resourceadjuster/controller_test.go
+++ b/internal/controller/resourceadjuster/controller_test.go
@@ -584,33 +584,44 @@ func TestCapChange(t *testing.T) {
 		current     string
 		recommended string
 		maxPct      float64
+		threshold   float64
 		wantAtMost  string // upper bound on result (result must be <= recommended and <= wantAtMost)
 		wantAtLeast string // result must be > current when drifting upward
 	}{
 		{
-			name: "small move, no cap needed",
-			// current=200m, recommended=210m, maxPct=50% → delta 10m <= 100m cap → use recommended
-			current: "200m", recommended: "210m", maxPct: 50,
-			wantAtMost: "210m", wantAtLeast: "200m",
+			name: "small move lands inside drift band, snaps to recommended",
+			// current=200m, recommended=210m: capped step 205m is within 20% of
+			// 210m, so the recommendation is applied exactly
+			current: "200m", recommended: "210m", maxPct: 50, threshold: 20,
+			wantAtMost: "210m", wantAtLeast: "210m",
 		},
 		{
 			name: "large move, cap applied upward",
-			// current=100m, recommended=300m, maxPct=50% → cap at 150m
-			current: "100m", recommended: "300m", maxPct: 50,
-			wantAtMost: "150m", wantAtLeast: "100m",
+			// current=100m, recommended=300m: gap 200m, step 100m → ~200m,
+			// still >20% from 300m so no snap
+			current: "100m", recommended: "300m", maxPct: 50, threshold: 20,
+			wantAtMost: "200m", wantAtLeast: "199m",
 		},
 		{
 			name: "large move, cap applied downward",
-			// current=300m, recommended=100m, maxPct=50% → cap at 150m
-			current: "300m", recommended: "100m", maxPct: 50,
-			wantAtMost: "300m", wantAtLeast: "149m",
+			// current=300m, recommended=100m: gap 200m, step 100m → ~200m,
+			// still >20% from 100m so no snap
+			current: "300m", recommended: "100m", maxPct: 50, threshold: 20,
+			wantAtMost: "200m", wantAtLeast: "199m",
+		},
+		{
+			name: "capped step within threshold of recommendation, snaps",
+			// current=100m, recommended=140m: gap 40m, step 20m → 120m, which is
+			// within 20% of 140m, so the recommendation is applied exactly
+			current: "100m", recommended: "140m", maxPct: 50, threshold: 20,
+			wantAtMost: "140m", wantAtLeast: "140m",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			cur := resource.MustParse(tc.current)
 			rec := resource.MustParse(tc.recommended)
-			result := resourceadjuster.CapChange(cur, rec, tc.maxPct)
+			result := resourceadjuster.CapChange(cur, rec, tc.maxPct, tc.threshold)
 			atMost := resource.MustParse(tc.wantAtMost)
 			atLeast := resource.MustParse(tc.wantAtLeast)
 			if result.Cmp(atMost) > 0 {
@@ -958,9 +969,10 @@ func TestCapChange_Memory(t *testing.T) {
 	// Memory uses BinarySI (bytes), not milli-units. Large move triggers the cap.
 	current := resource.MustParse("100Mi")
 	recommended := resource.MustParse("300Mi")
-	result := resourceadjuster.CapChange(current, recommended, 50)
-	// maxDelta = 100Mi * 50% = 50Mi; capped result = 150Mi
-	expectedCap := resource.MustParse("150Mi")
+	result := resourceadjuster.CapChange(current, recommended, 50, 20)
+	// gap = 200Mi, step = 200Mi * 50% = 100Mi; capped result = 200Mi,
+	// still >20% from 300Mi so no snap
+	expectedCap := resource.MustParse("200Mi")
 	if result.Cmp(expectedCap) > 0 {
 		t.Errorf("CapChange memory result %s exceeds cap %s", result.String(), expectedCap.String())
 	}
@@ -973,9 +985,32 @@ func TestCapChange_CurrentZero(t *testing.T) {
 	// When current is zero, CapChange returns the recommended value directly.
 	current := resource.MustParse("0")
 	recommended := resource.MustParse("200m")
-	result := resourceadjuster.CapChange(current, recommended, 50)
+	result := resourceadjuster.CapChange(current, recommended, 50, 20)
 	if result.Cmp(recommended) != 0 {
 		t.Errorf("CapChange with current=0: expected %s, got %s", recommended.String(), result.String())
+	}
+}
+
+func TestCapChange_ConvergesExactly(t *testing.T) {
+	// Regression test for the Zeno tail: capping each step at 50% of the
+	// remaining gap must still terminate exactly at the recommendation, not
+	// park just inside the drift band. Simulates the resize loop (resize only
+	// while drift exceeds the threshold) for a badly underprovisioned workload.
+	cur := resource.MustParse("15m")
+	rec := resource.MustParse("145m")
+	steps := 0
+	for resourceadjuster.ExceedsDrift(cur, rec, 20) {
+		cur = resourceadjuster.CapChange(cur, rec, 50, 20)
+		steps++
+		if steps > 10 {
+			t.Fatalf("did not converge after %d steps; stuck at %s", steps, cur.String())
+		}
+	}
+	if cur.Cmp(rec) != 0 {
+		t.Errorf("converged to %s inside the drift band; want exact recommendation %s", cur.String(), rec.String())
+	}
+	if steps > 4 {
+		t.Errorf("took %d steps to converge; want at most 4", steps)
 	}
 }
 


### PR DESCRIPTION
## Problem

`maxChangePerCycle` is documented as capping a resize step relative to the move toward the recommendation, but `CapChange` computed the cap as a percentage of the **current** value. For an underprovisioned workload this converges backwards: with the default 50%, each cycle can grow the request by at most 1.5x its current value, so correction starts with tiny steps and accelerates (15m → 22m → 34m → 50m → 76m → snap), taking hours to close a large gap. Observed in production as an exponential staircase in `k8s.container.cpu_request`.

## Fix

`CapChange` now caps each step at `maxChangePerCycle` percent of the gap between current and recommended, so the first cycle makes the largest correction and later cycles refine it.

A pure percentage-of-gap step never reaches the target (Zeno), and worse, the drift gate stops resizing once the value is within the threshold of the recommendation; converging from below, that can park a request at up to `rec / 1.2` for the default 20% threshold. Since the default recommendation is `1.2 * avg usage`, the worst-case resting point would be the observed average usage with zero headroom. To prevent that, `CapChange` takes the drift threshold and applies the recommendation **exactly** when the capped step would land inside the drift band (the next cycle would not fire anyway). With the defaults, convergence completes in at most a few cycles from any starting point: 15m → 80m → 112m → 145m.

## Changes

- `CapChange(current, recommended, maxChangePct, thresholdPct)`: gap-based cap plus terminal snap; `ExceedsDrift` refactored onto a shared float helper
- Tests: reworked `TestCapChange` (including a snap-boundary case), updated memory/current-zero tests, and added `TestCapChange_ConvergesExactly`, a Zeno regression test that replays the resize loop from 15m to a 145m recommendation and asserts exact convergence in <= 4 cycles
- Docs: corrected `maxChangePerCycle` semantics in the CRD field comment (CRD `description` strings regenerated via `make manifests`; no schema changes), `values.yaml`, README, DESIGN.md, AGENTS.md, IMPLEMENTATION_PLAN.md
- CHANGELOG `[Unreleased]` Fixed entry

## Verification

- `make lint`: 0 issues
- `make test-coverage-check`: all tests pass, coverage gate green (77.1%)