### PR TITLE
Demote 'excluding drifted resources' log from info to debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Demoted the "excluding drifted resources the resize subresource cannot mutate" log line from info to debug (`V(1)`).** This fires on every reconcile of a pod whose only drift is on a resource in-place resize cannot touch, which is expected steady-state behavior, not something an operator needs to see at info level. It was dominating operator logs. The message is unchanged and still emitted; raise log verbosity to `1` to see it.
+
 ## [0.3.13] - 2026-07-03
 
 ### Changed

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -199,7 +199,7 @@ func (r *Reconciler) reconcilePod(ctx context.Context, pod *corev1.Pod, profile 
 	recsByName := containerRecsByName(profile)
 	adjustments, notResizable := computeAdjustments(pod, recsByName, behaviors)
 	if len(notResizable) > 0 {
-		log.Info("excluding drifted resources the resize subresource cannot mutate",
+		log.V(1).Info("excluding drifted resources the resize subresource cannot mutate",
 			"pod", pod.Name, "namespace", pod.Namespace, "resources", notResizable)
 	}
 	if len(adjustments) == 0 {


### PR DESCRIPTION
## What

Demotes the `excluding drifted resources the resize subresource cannot mutate` log line from info to debug (`V(1)`), matching the neighboring cooldown log.

## Why

This line fires on every reconcile of a pod whose only drift is on a resource in-place resize cannot mutate (e.g. ephemeral-storage), which is expected steady-state behavior, not something an operator needs at info level. It was dominating operator logs on large clusters. The message is unchanged and still emitted; raise log verbosity to `1` to see it.

## Notes

Follow-up work (the underlying reconcile churn that made this line so frequent) lands on a separate branch cut from this one.