### PR TITLE
Filter ResourceAdjuster watch to resize-relevant profile changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The ResourceAdjuster no longer re-evaluates every WorkloadProfile on each metrics poll.** Its watch previously had no predicate, so every status write the MetricsCollector makes (~once per poll, ~60s, as recommendation percentiles drift with fresh samples) woke the adjuster and made it re-list pods and recompute drift for that profile, roughly 15x more often than its resize interval implies. On large clusters that churn pinned operator CPU while doing no useful work (the adjuster reads whatever recommendations are current when it runs). The watch now filters updates to those the adjuster acts on: spec (`generation`) changes and `status.meetsThreshold` transitions still pass, so a profile that becomes ready is resized promptly, while the intermediate recommendation churn is ignored and pacing falls to the resize interval as intended. This also stops the `excluding drifted resources...` debug line from being emitted on every poll.
+
 - **Demoted the "excluding drifted resources the resize subresource cannot mutate" log line from info to debug (`V(1)`).** This fires on every reconcile of a pod whose only drift is on a resource in-place resize cannot touch, which is expected steady-state behavior, not something an operator needs to see at info level. It was dominating operator logs. The message is unchanged and still emitted; raise log verbosity to `1` to see it.
 
 ## [0.3.13] - 2026-07-03

--- a/internal/controller/resourceadjuster/controller.go
+++ b/internal/controller/resourceadjuster/controller.go
@@ -20,7 +20,10 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	ballastv1 "github.com/tight-line/ballast/api/v1"
 	"github.com/tight-line/ballast/internal/controller/workloadwatcher"
@@ -83,8 +86,40 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("resourceadjuster").
 		WithLogConstructor(logger.ControllerLogConstructor(mgr.GetLogger(), "resourceadjuster")).
-		For(&ballastv1.WorkloadProfile{}).
+		For(&ballastv1.WorkloadProfile{}, builder.WithPredicates(resizeRelevantChange())).
 		Complete(r)
+}
+
+// resizeRelevantChange filters the WorkloadProfile update stream down to the
+// events the adjuster actually acts on. The metricscollector rewrites profile
+// status every poll (~60s) as recommendation percentiles drift with fresh
+// samples; without a predicate, every one of those status writes wakes the
+// adjuster, so it re-lists pods and recomputes drift ~15x more often than its
+// resize interval implies. That churn pins CPU on large clusters and does no
+// useful work: the adjuster reads whatever recommendations are current when it
+// runs, so it loses nothing by ignoring the intermediate writes and relying on
+// its own RequeueAfter for pacing.
+//
+// An update passes only when the spec changed (Generation) or the profile
+// crossed the readiness boundary (Status.MeetsThreshold flipped) so the first
+// resize after a profile becomes ready is not delayed a full interval. Create,
+// delete, and generic events pass by default (predicate.Funcs treats nil funcs
+// as true): new profiles must be evaluated, and Reconcile handles a deleted
+// profile as a no-op NotFound.
+func resizeRelevantChange() predicate.Predicate {
+	return predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldP, ok1 := e.ObjectOld.(*ballastv1.WorkloadProfile)
+			newP, ok2 := e.ObjectNew.(*ballastv1.WorkloadProfile)
+			if !ok1 || !ok2 {
+				// The manager only delivers typed WorkloadProfiles here; admit
+				// anything unexpected rather than silently dropping it.
+				return true
+			}
+			return oldP.Generation != newP.Generation ||
+				oldP.Status.MeetsThreshold != newP.Status.MeetsThreshold
+		},
+	}
 }
 
 // Reconcile evaluates drift for each pod associated with the profile and issues
@@ -584,7 +619,7 @@ func truncate(s string, n int) string {
 func (r *Reconciler) emitEvent(ctx context.Context, pod *corev1.Pod, eventType, reason, message string) {
 	log := ctrl.LoggerFrom(ctx)
 	now := metav1.Now()
-	event := &corev1.Event{
+	evt := &corev1.Event{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("%s.%s.%d", pod.Name, strings.ToLower(reason), now.UnixNano()),
 			Namespace: pod.Namespace,
@@ -604,7 +639,7 @@ func (r *Reconciler) emitEvent(ctx context.Context, pod *corev1.Pod, eventType, 
 		Count:          1,
 		Source:         corev1.EventSource{Component: "ballast"},
 	}
-	if err := r.client.Create(ctx, event); err != nil { // coverage:ignore - non-fatal; requires a broken client to trigger
+	if err := r.client.Create(ctx, evt); err != nil { // coverage:ignore - non-fatal; requires a broken client to trigger
 		log.Error(err, "failed to emit event", "reason", reason)
 	}
 }

--- a/internal/controller/resourceadjuster/watch_internal_test.go
+++ b/internal/controller/resourceadjuster/watch_internal_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 Tight Line LLC.
+
+Licensed under the MIT License. See LICENSE for the full text.
+*/
+
+package resourceadjuster
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	ballastv1 "github.com/tight-line/ballast/api/v1"
+)
+
+// These tests live in the internal package so they can exercise the unexported
+// resizeRelevantChange predicate directly, covering every closure branch.
+
+func profile(generation int64, meetsThreshold bool) *ballastv1.WorkloadProfile {
+	return &ballastv1.WorkloadProfile{
+		ObjectMeta: metav1.ObjectMeta{Generation: generation},
+		Status:     ballastv1.WorkloadProfileStatus{MeetsThreshold: meetsThreshold},
+	}
+}
+
+func TestResizeRelevantChangePredicate(t *testing.T) {
+	p := resizeRelevantChange()
+
+	// A pure status rewrite (same generation, same readiness) is the per-poll
+	// recommendation churn the collector emits; it must be filtered.
+	if p.Update(event.UpdateEvent{ObjectOld: profile(3, true), ObjectNew: profile(3, true)}) {
+		t.Error("status-only churn should be filtered")
+	}
+
+	// A spec edit bumps generation and must pass.
+	if !p.Update(event.UpdateEvent{ObjectOld: profile(3, true), ObjectNew: profile(4, true)}) {
+		t.Error("generation change should pass")
+	}
+
+	// Crossing the readiness boundary must pass so the first resize is not
+	// delayed a full interval, in either direction.
+	if !p.Update(event.UpdateEvent{ObjectOld: profile(3, false), ObjectNew: profile(3, true)}) {
+		t.Error("readiness false->true should pass")
+	}
+	if !p.Update(event.UpdateEvent{ObjectOld: profile(3, true), ObjectNew: profile(3, false)}) {
+		t.Error("readiness true->false should pass")
+	}
+
+	// A non-WorkloadProfile update (which the manager never delivers) is
+	// admitted rather than dropped.
+	if !p.Update(event.UpdateEvent{ObjectOld: &corev1.Pod{}, ObjectNew: &corev1.Pod{}}) {
+		t.Error("unexpected object type should be admitted")
+	}
+
+	// Create, delete, and generic events pass by default so new profiles are
+	// evaluated and deletions reconcile to a NotFound no-op.
+	if !p.Create(event.CreateEvent{Object: profile(1, false)}) {
+		t.Error("create should pass")
+	}
+	if !p.Delete(event.DeleteEvent{Object: profile(1, true)}) {
+		t.Error("delete should pass")
+	}
+	if !p.Generic(event.GenericEvent{Object: profile(1, true)}) {
+		t.Error("generic should pass")
+	}
+}


### PR DESCRIPTION
## Problem

The ResourceAdjuster's WorkloadProfile watch had no predicate, so it enqueued on *every* profile event, including status-only updates. The MetricsCollector rewrites profile status on every poll (~60s) as recommendation percentiles drift with fresh samples, so each of those writes woke the adjuster and made it re-list pods and recompute drift for that profile: roughly 15x more often than its resize interval (default 15m) implies.

On large clusters (~5000 pods) that churn pins operator CPU while doing no useful work. The adjuster reads whatever recommendations are current when it runs, so it loses nothing by ignoring the intermediate writes and pacing on its own `RequeueAfter`. It also caused the `excluding drifted resources...` debug line to be emitted on every poll for pods whose only drift is on a non-resizable resource (e.g. ephemeral-storage), which is what surfaced the churn in the first place.

## Fix

Add `resizeRelevantChange`, a watch predicate that admits an update only when:

- the spec changed (`metadata.generation`), or
- the profile crossed the readiness boundary (`status.meetsThreshold` flipped), so the first resize after a profile becomes ready is not delayed a full interval.

Create/delete/generic events pass by default (`predicate.Funcs` treats nil funcs as true): new profiles must be evaluated, and `Reconcile` handles a deleted profile as a NotFound no-op. This mirrors the `GenerationChangedPredicate` the MetricsCollector already uses, extended to keep readiness transitions responsive.

A local variable named `event` in `emitEvent` was renamed to `evt` to free the `event` package name, keeping the import idiomatic (matching `workloadwatcher`).

## Tests

`watch_internal_test.go` (internal package, mirroring `workloadwatcher`'s `watch_internal_test.go`) covers every branch: status-only churn filtered, generation change passes, readiness flip passes in both directions, unexpected object type admitted, and create/delete/generic pass.

`make lint` and `make test-coverage-check` both green.