### PR TITLE
Persist and bound the bundled Valkey sample store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **The bundled Valkey sample store now persists to a PersistentVolumeClaim and is memory-bounded, so accrued history survives pod reschedules.** Previously the bundled Valkey ran with the subchart defaults: an `emptyDir` for `/data` and `resources: {}` (BestEffort QoS). That combination is the worst case for a sample store. BestEffort is the first thing the kubelet evicts under node memory pressure, and every eviction or reschedule wiped all samples and every first-seen marker. Because readiness gates on `minTimeSpan` (default 24h of observed history), a wipe silently reset the entire fleet to `Accruing` for 24h, and any further restart in that window restarted the clock, so on a busy cluster the fleet could stay perpetually `Accruing` without ever reaching `Sufficient`. The chart now enables `dataStorage` (a PVC on the cluster's default StorageClass; `valkey.dataStorage.className` pins a specific one) with `deploymentStrategy: Recreate` (a single-replica Deployment cannot roll onto a ReadWriteOnce PVC otherwise), sets `maxmemory 64mb` with `maxmemory-policy noeviction` (never evict first-seen markers; refuse writes loudly instead of being OOM-killed), and sets Valkey's memory request equal to its limit (`96Mi`) to lift it out of BestEffort. Valkey reloads its RDB snapshot from the PVC on start, so history is preserved across reschedules.
+
+  The defaults are deliberately small (fine for dev and modest fleets). **They are linked and must be scaled together:** `maxmemory < memory limit <= memory request`, and PVC size `~= 2 × memory limit` (a background save writes a temporary RDB alongside the live one). The driver is dataset size, roughly `reservoirSize × (containers × metrics)`; raise `maxmemory`, the limit, the request, and the PVC in lockstep for larger clusters. See the annotated `valkey:` block in `values.yaml`.
+
+  **Migration:** the first upgrade rolls the Valkey pod once (a final store reset, so the fleet re-accrues from that point) and provisions the PVC; there is no persistence across that single roll. Clusters using an external store (`valkey.enabled: false`) are unaffected.
+
 ## [0.3.16] - 2026-07-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](http
 - Kubernetes 1.35+ (required for in-place pod resize; earlier versions support measure and apply but not resize)
 - [metrics-server](https://github.com/kubernetes-sigs/metrics-server) installed in the cluster (source for CPU and memory; ephemeral-storage usage comes from the kubelet Summary API and needs no extra component)
 - TLS certificate for the admission webhook (see [Webhook TLS](#webhook-tls) below)
-- A Redis-compatible store (Ballast ships with a bundled Valkey via Helm; an existing Redis or Valkey instance works too)
+- A Redis-compatible store (Ballast ships with a bundled Valkey via Helm; an existing Redis or Valkey instance works too). The bundled Valkey persists to a PersistentVolumeClaim on the cluster's default StorageClass by default, so accrued history survives pod reschedules; its memory and storage defaults are small and linked, so scale them together (see the annotated `valkey:` block in `values.yaml`).
 
 ## Installation
 

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -96,8 +96,82 @@ ballastConfig:
 
 # Official Valkey subchart (valkey-io/valkey-helm, BSD-licensed). Set enabled: false
 # and provide store.endpoint to use an external Redis/Valkey instance instead.
+#
+# ############################################################################
+# #                                                                          #
+# #   !!!  READ THIS BEFORE CHANGING ANY VALKEY MEMORY OR STORAGE VALUE  !!!  #
+# #                                                                          #
+# #   The four sizing knobs below are LINKED. They ship small on purpose     #
+# #   (fine for dev and modest fleets) and you MUST move them together when  #
+# #   you scale up. The relationship is:                                     #
+# #                                                                          #
+# #       maxmemory  <  memory limit  <=  memory request                     #
+# #       PVC size   ~=  2 x memory limit                                    #
+# #                                                                          #
+# #   WHY each one:                                                          #
+# #     * maxmemory (valkeyConfig) is where valkey stops accepting writes.   #
+# #       Set it BELOW the container limit so valkey refuses new samples     #
+# #       gracefully instead of being OOM-killed. Keep policy noeviction:    #
+# #       samples and their first-seen markers have no TTL, and evicting a   #
+# #       first-seen key silently resets that workload to Accruing.          #
+# #     * memory request == limit keeps the pod out of BestEffort QoS. The   #
+# #       subchart default (resources: {}) is BestEffort, the FIRST thing    #
+# #       the kubelet evicts under node memory pressure, and an evicted      #
+# #       valkey loses its store. This is the failure that motivated these   #
+# #       defaults.                                                          #
+# #     * PVC size ~= 2x the limit: a background save writes a fresh temp    #
+# #       RDB next to the live dump.rdb before renaming, so two snapshots    #
+# #       must fit at once. RDB compresses, so 2x is generous.               #
+# #                                                                          #
+# #   The independent variable is the dataset size, roughly                  #
+# #   reservoirSize x (containers x metrics per container). If you raise     #
+# #   maxmemory to fit a bigger fleet, raise the limit, the request, AND     #
+# #   the PVC in lockstep. Bump ONE in isolation and you get either an       #
+# #   OOM-killed store or a full PVC that cannot snapshot.                   #
+# #                                                                          #
+# ############################################################################
 valkey:
   enabled: true
+
+  # A ReadWriteOnce PVC (below) cannot be mounted by a new pod while the old
+  # pod still holds it, so a RollingUpdate deadlocks. Recreate terminates the
+  # old pod first. Single replica, so there is no availability cost.
+  deploymentStrategy: Recreate
+
+  # request == limit lifts the pod out of BestEffort (see banner). No CPU limit:
+  # a cache should not be CPU-throttled.
+  resources:
+    requests:
+      cpu: 50m
+      memory: 96Mi
+    limits:
+      memory: 96Mi
+
+  # maxmemory sits below the 96Mi container limit so valkey refuses writes
+  # gracefully rather than getting OOM-killed; noeviction protects first-seen
+  # markers (see banner). If valkey hits maxmemory, collection stalls with a
+  # loud error: raise maxmemory, the limit, the request, and the PVC together.
+  valkeyConfig: |
+    maxmemory 64mb
+    maxmemory-policy noeviction
+
+  # Persist the sample store to a PersistentVolumeClaim so accrued history
+  # survives valkey pod reschedules (node drains, evictions, upgrades). Without
+  # this the subchart backs /data with an emptyDir, so any reschedule wipes
+  # every sample and every first-seen marker; because readiness gates on
+  # minTimeSpan (default 24h of observed history), a wipe resets the whole fleet
+  # to Accruing until 24h re-accrues, and any further restart in that window
+  # restarts the clock. With a PVC, valkey reloads /data on start and the
+  # accrued history is preserved.
+  dataStorage:
+    enabled: true
+    # requestedSize MUST be non-empty or the subchart silently falls back to
+    # emptyDir (the exact failure above). Sized at ~2x the memory limit; scale
+    # it with the memory knobs (see banner).
+    requestedSize: 192Mi
+    # className empty ("") uses the cluster's default StorageClass. Set it to
+    # pin a specific class (e.g. a faster or retained one).
+    className: ""
 
 store:
   # endpoint is used when valkey.enabled is false.


### PR DESCRIPTION
Fixes #56.

## Problem

The bundled Valkey sample store ran with the subchart defaults: an `emptyDir` for `/data` and `resources: {}` (BestEffort QoS). BestEffort is the first thing the kubelet evicts under node memory pressure, and an `emptyDir` loses everything on reschedule, so each eviction wiped all samples and every `first_seen` marker. Because readiness gates on `minTimeSpan` (default 24h), a wipe reset the entire fleet to `Accruing` for 24h, and any restart in that window restarted the clock, so a busy cluster could stay perpetually `Accruing` and never resize anything.

Mechanism: `timeSpan = lastMs - firstMs`, where `firstMs` is a `SETNX` `first_seen` key trimmed by count, never by age; a reschedule onto a fresh `emptyDir` acts as a `FLUSHDB`, so `timeSpan` collapses to ~0 and climbs from the reschedule time regardless of profile age, failing the `minTimeSpan` gate fleet-wide. Distinct from the 0.3.13 resolve-time-defaults change, which fixed a different Accruing cause.

## Change

Turns the bundled Valkey into a real, bounded, durable store (subchart kept; parent `values.yaml` config only):

- `dataStorage.enabled: true`, `requestedSize: 192Mi`, `className: ""` (cluster default StorageClass, overridable). Valkey reloads its RDB from the PVC on start, so history survives reschedules.
- `deploymentStrategy: Recreate` (a single-replica Deployment can't roll onto a ReadWriteOnce PVC without deadlocking).
- `valkeyConfig`: `maxmemory 64mb` + `maxmemory-policy noeviction` (never evict `first_seen` markers; refuse writes loudly rather than OOM).
- `resources`: memory `request == limit == 96Mi` (out of BestEffort), `cpu` request only (no CPU throttling on a cache).

Defaults ship small (fine for dev/modest fleets) and are **linked**: `maxmemory < limit <= request`, PVC `~= 2 × limit`. A very loud banner in `values.yaml` explains the relationship and that they must scale together.

## Migration

First upgrade rolls the Valkey pod once (a final store reset; the fleet re-accrues from that point) and provisions the PVC. Clusters on an external store (`valkey.enabled: false`) are unaffected.

## Verification

- `make helm-lint` passes.
- `make helm-template` renders: a `ballast-valkey` PVC (192Mi, RWO, no explicit storageClassName -> default), the Deployment with `strategy.type: Recreate`, the data volume as a `persistentVolumeClaim` (not `emptyDir`), memory request/limit `96Mi`, and the config with `maxmemory 64mb` / `noeviction` mounted and appended to the running `valkey.conf`.
- No dependency change (Chart.lock still valkey 0.10.0).

_Versioning left to the release process; CHANGELOG entry is under `[Unreleased]`._