### PR TITLE
Add Helm tolerations support for operator and Valkey pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Helm: `tolerations` support for the operator and Valkey pods.** A new top-level `tolerations` value is applied to both the operator Deployment and the pre-install/pre-upgrade `crd-upgrade-hook` Job (a taint that keeps Ballast off a node should keep its bootstrap Job off it too, otherwise the hook fails to schedule and blocks the install/upgrade before the operator starts). The Valkey store's tolerations are set via `valkey.tolerations`, which passes straight through to the upstream subchart. All default to empty, so this is additive. ([#62](https://github.com/Tight-Line/ballast/issues/62))
+
 ## [0.4.0] - 2026-07-20
 
 > ⚠️ **BREAKING RELEASE.** This release changes the enrollment API. **Every enrolled

--- a/charts/ballast/templates/crd-upgrade-hook.yaml
+++ b/charts/ballast/templates/crd-upgrade-hook.yaml
@@ -75,6 +75,10 @@ spec:
     spec:
       serviceAccountName: {{ include "ballast.fullname" . }}-crd-upgrade
       restartPolicy: Never
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/charts/ballast/templates/deployment.yaml
+++ b/charts/ballast/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
         {{- include "ballast.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "ballast.serviceAccountName" . }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         runAsNonRoot: true
         seccompProfile:

--- a/charts/ballast/values.yaml
+++ b/charts/ballast/values.yaml
@@ -38,6 +38,18 @@ resources:
     memory: 64Mi
     ephemeral-storage: 64Mi
 
+# tolerations for the operator pods. Applied to both the operator Deployment and
+# the pre-install/pre-upgrade crd-upgrade-hook Job — a taint that keeps Ballast
+# off a node should keep its bootstrap Job off it too, otherwise the hook fails
+# to schedule and blocks the whole install/upgrade before the operator starts.
+# Empty by default. To schedule Ballast onto tainted nodes, e.g.:
+#   tolerations:
+#     - key: dedicated
+#       operator: Equal
+#       value: platform
+#       effect: NoSchedule
+tolerations: []
+
 logging:
   level: info
   # Per-component overrides. Leave empty to inherit the global level.
@@ -137,6 +149,13 @@ valkey:
   # pod still holds it, so a RollingUpdate deadlocks. Recreate terminates the
   # old pod first. Single replica, so there is no availability cost.
   deploymentStrategy: Recreate
+
+  # tolerations for the Valkey pod. Passed straight through to the upstream
+  # valkey subchart's top-level `tolerations`. Empty by default; set it (same
+  # shape as the operator `tolerations` above) to schedule the store onto
+  # tainted nodes. Note the store holds a ReadWriteOnce PVC, so keep it able to
+  # schedule wherever that volume can attach.
+  tolerations: []
 
   # request == limit lifts the pod out of BestEffort (see banner). No CPU limit:
   # a cache should not be CPU-throttled.


### PR DESCRIPTION
## Summary

Adds `tolerations` support to the Helm chart so the operator can be scheduled onto tainted nodes (dedicated node pools, spot/preemptible pools, etc.) without hand-editing rendered manifests.

- New top-level `tolerations` value, applied to **both** the operator Deployment and the `pre-install`/`pre-upgrade` **crd-upgrade-hook Job**. The Job runs before the operator starts, so it needs the same tolerations; otherwise a taint that keeps Ballast off a node would fail the hook and block the whole install/upgrade.
- `valkey.tolerations` surfaced in `values.yaml`; it passes straight through to the upstream Valkey subchart's top-level `tolerations`.

All values default to empty, so this is additive and non-breaking.

## Testing

- `helm template` with tolerations set: renders on the operator Deployment, the crd-upgrade Job, and the Valkey pod.
- `helm template` with defaults: no `tolerations` key emitted.
- `helm lint` passes.

Closes #62