### PR TITLE
Harden CI: least-privilege permissions, harden-runner, fork-PR safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+# Least privilege by default; no job here needs write access.
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -13,6 +17,11 @@ jobs:
       # Empty on Dependabot/fork runs, which get no access to Actions secrets.
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
@@ -40,6 +49,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
@@ -54,6 +68,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go
@@ -68,6 +87,11 @@ jobs:
   govulncheck:
     runs-on: ubuntu-latest
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go

--- a/.github/workflows/pr-images.yml
+++ b/.github/workflows/pr-images.yml
@@ -8,8 +8,15 @@ on:
 env:
   REGISTRY: ghcr.io
 
+permissions:
+  contents: read
+
 jobs:
-  build:
+  image:
+    name: Build and push PR image
+    # Fork PRs run with a read-only token and no secrets, so the GHCR push would
+    # fail; restrict the build to same-repo PRs and let forks skip it cleanly.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,6 +24,11 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Docker Buildx

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 env:
   REGISTRY: ghcr.io
 
+permissions:
+  contents: read
+
 jobs:
   release-image:
     name: Build and push container image
@@ -17,6 +20,11 @@ jobs:
       packages: write
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Docker Buildx
@@ -77,6 +85,11 @@ jobs:
       contents: write
 
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -8,15 +8,26 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Weekly Monday 6am UTC
 
+permissions:
+  contents: read
+
 jobs:
   snyk:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write  # upload Snyk SARIF to code scanning
     env:
       # Empty on Dependabot/fork runs, which get no access to Actions secrets.
       # Go dependency bumps are still gated by the tokenless govulncheck job in
       # ci.yml; Snyk runs fully on trusted PRs, on push to main, and on schedule.
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Set up Go

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -6,13 +6,24 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   sonarcloud:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read  # SonarCloud PR analysis reads PR metadata
     env:
       # Empty on Dependabot/fork runs, which get no access to Actions secrets.
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0  # Full history for accurate blame and new-code detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **CI supply-chain hardening.** Every workflow now declares least-privilege `permissions:` (read-only by default, with write scopes granted only to the specific jobs that need them, such as `security-events: write` for SARIF upload and `packages: write` for image push). `step-security/harden-runner` runs in audit mode as the first step of every job to monitor runner egress. The PR image build is restricted to same-repo pull requests (fork PRs get a read-only token and no secrets, so they skip it cleanly instead of failing on the GHCR push), and that job was renamed `build` → `image` to remove its name collision with the CI `build` check.
+
 ## [0.4.5] - 2026-07-24
 
 ### Security

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,8 +66,12 @@ via the process above.
 - [x] Secret-dependent CI steps fail safe: they skip rather than run on untrusted
       (Dependabot/fork) runs, so repository secrets are never exposed to builds of
       untrusted dependency code
-- [ ] Least-privilege `permissions:` blocks on every workflow
-- [ ] Egress monitoring on CI runners (e.g. `step-security/harden-runner`)
+- [x] Untrusted (fork) pull requests cannot reach registry credentials: the PR
+      image build is restricted to same-repo pull requests
+- [x] Least-privilege `permissions:` on every workflow (read-only by default;
+      write scopes granted only to the jobs that need them)
+- [x] Egress monitoring on CI runners via `step-security/harden-runner`
+      (audit mode; block-mode enforcement is being rolled out)
 - [ ] OpenSSF Scorecard workflow and badge
 
 ### Published artifacts


### PR DESCRIPTION
## What

Workstream C: defense-in-depth for the build pipeline, so a compromised step (poisoned dependency or action) has minimal token scope, can't exfiltrate freely, and untrusted fork code never reaches secrets.

## Changes

### 1. Least-privilege `permissions:`

Every workflow now declares explicit permissions instead of inheriting the repo default:

| Workflow | Default | Job overrides |
|---|---|---|
| `ci.yml` | `contents: read` | none (all jobs read-only) |
| `snyk.yml` | `contents: read` | `security-events: write` (SARIF upload) |
| `sonar.yml` | `contents: read` | `pull-requests: read` |
| `pr-images.yml` | `contents: read` | `packages: write`, `pull-requests: write` |
| `release.yml` | `contents: read` | image: `packages: write`; chart: `contents: write` |

`ci.yml` previously had no block at all, so it ran with whatever the repo default grants; now it's read-only.

### 2. harden-runner (egress monitoring)

`step-security/harden-runner` (pinned to `bf7454d0…` / v2.20.0) runs as the first step of every job in **audit mode**. It records the runner's outbound connections without blocking. Once we've confirmed the legitimate endpoints (Go module proxy, GitHub, GHCR, Codecov/Snyk/Sonar) from the audit insights, we flip it to **block** mode with that allowlist in a follow-up.

### 3. Fork-PR safety

`pr-images.yml` builds a container image from PR code. It already used `pull_request` (not `pull_request_target`), so there was no secret-exposure hole, but a fork PR's GHCR push would fail because its token is read-only. The build is now gated to same-repo PRs (`if: github.event.pull_request.head.repo.full_name == github.repository`), so fork PRs skip it cleanly. The job was renamed `build` → `image`, which also removes its name collision with the CI `build` check (the source of the earlier ambiguous `BLOCKED` states).

## Verification

- All five workflow YAML files parse.
- `snyk` and `sonar` run on this PR, so their new scoped permissions are exercised here (SARIF upload needs `security-events: write`); if I under-scoped, those checks will fail on this PR.
- `pr-images` runs on this PR (same-repo), validating the rename + fork-gate + harden-runner.
- `release.yml` only runs on tag push, so it isn't exercised until the next release; its changes are the read-only default + audit-mode harden-runner (non-breaking), with job-level write scopes unchanged.

## Follow-up

- Flip harden-runner from `audit` to `block` with the learned egress allowlist.
- Remaining roadmap: D (signing/provenance/SBOM), E (RBAC + securityContext), B (dependency-review + Scorecard).