### PR TITLE
Workstream D: sign image + chart; cross-compile arm64 into one signed multi-arch build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write       # keyless cosign signing + provenance (GitHub OIDC)
+      attestations: write   # actions/attest-build-provenance
 
     steps:
       - name: Harden the runner
@@ -26,6 +28,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             github.com:443
+            api.github.com:443
             proxy.golang.org:443
             sum.golang.org:443
             storage.googleapis.com:443
@@ -36,6 +39,11 @@ jobs:
             production.cloudfront.docker.com:443
             gcr.io:443
             *.githubapp.com:443
+            release-assets.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
@@ -76,6 +84,7 @@ jobs:
 
       # Then build multi-arch (updates tags in-place with manifest)
       - name: Build and push ballast (multi-arch)
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
@@ -89,6 +98,38 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Sign the pushed image, attest an SBOM, and attach SLSA build provenance —
+      # all keyless via GitHub OIDC + sigstore, written to GHCR as OCI artifacts
+      # so consumers can `cosign verify` / `cosign verify-attestation` the image.
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Sign image (keyless)
+        env:
+          IMAGE: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign sign --yes "${IMAGE}@${DIGEST}"
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          image: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast@${{ steps.build.outputs.digest }}
+          format: spdx-json
+          output-file: sbom.spdx.json
+
+      - name: Attest SBOM (keyless)
+        env:
+          IMAGE: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${IMAGE}@${DIGEST}"
+
+      - name: Attest SLSA build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
 
   release-chart:
     name: Package and publish Helm chart

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,7 +135,10 @@ jobs:
     name: Package and publish Helm chart
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write       # chart-releaser: GitHub release + gh-pages
+      packages: write       # push the chart as an OCI artifact to GHCR
+      id-token: write       # keyless cosign signing + provenance (GitHub OIDC)
+      attestations: write   # actions/attest-build-provenance
 
     steps:
       - name: Harden the runner
@@ -150,6 +153,12 @@ jobs:
             get.helm.sh:443
             valkey-io.github.io:443
             valkey.io:443
+            ghcr.io:443
+            pkg-containers.githubusercontent.com:443
+            objects.githubusercontent.com:443
+            fulcio.sigstore.dev:443
+            rekor.sigstore.dev:443
+            tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -188,3 +197,45 @@ jobs:
           skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      # Also publish the chart as a signed OCI artifact to GHCR, alongside the
+      # GitHub Pages repo above (additive; the `helm repo add` URL still works).
+      # Consumers can `helm pull oci://ghcr.io/<owner>/charts/ballast` and
+      # `cosign verify`. Keyless via GitHub OIDC + sigstore.
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
+
+      - name: Package and push chart (OCI)
+        id: oci
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          echo "$GH_TOKEN" | helm registry login ghcr.io -u "$ACTOR" --password-stdin
+          helm package charts/ballast --destination .cr-oci
+          chart_tgz="$(ls .cr-oci/ballast-*.tgz)"
+          helm push "$chart_tgz" "oci://ghcr.io/${owner}/charts" 2>&1 | tee push.log
+          digest="$(grep -oiE 'sha256:[0-9a-f]{64}' push.log | head -1)"
+          echo "ref=ghcr.io/${owner}/charts/ballast" >> "$GITHUB_OUTPUT"
+          echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+
+      - name: Sign chart (keyless)
+        env:
+          REF: ${{ steps.oci.outputs.ref }}
+          DIGEST: ${{ steps.oci.outputs.digest }}
+        run: cosign sign --yes "${REF}@${DIGEST}"
+
+      - name: Attest chart build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-name: ${{ steps.oci.outputs.ref }}
+          subject-digest: ${{ steps.oci.outputs.digest }}
+          push-to-registry: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,24 +66,11 @@ jobs:
           echo "TAG=${TAG}" >> $GITHUB_OUTPUT
           echo "IMAGE_PREFIX=ghcr.io/${GITHUB_REPOSITORY_OWNER,,}" >> $GITHUB_OUTPUT
 
-      # Build amd64 first for fast availability (native build, ~2 min)
-      - name: Build and push ballast (amd64)
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          file: ./Dockerfile
-          push: true
-          build-args: |
-            VERSION=${{ steps.meta.outputs.VERSION }}
-          tags: |
-            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:${{ steps.meta.outputs.TAG }}
-            ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast:latest
-          platforms: linux/amd64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      # Then build multi-arch (updates tags in-place with manifest)
-      - name: Build and push ballast (multi-arch)
+      # Single multi-arch build. The Dockerfile cross-compiles (builder runs on
+      # the native runner via --platform=$BUILDPLATFORM), so arm64 is fast and
+      # there is no separate amd64-first push — the tags are only ever set once,
+      # by this build, which is the one that gets signed below (no unsigned window).
+      - name: Build and push ballast
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Released container images are now signed, with an SBOM and SLSA build provenance.** The release workflow signs the pushed image keylessly with cosign (GitHub OIDC + sigstore, no key to manage), attaches a syft-generated SPDX SBOM as a cosign attestation, and attaches SLSA build provenance (`actions/attest-build-provenance`, also pushed to the registry as an OCI attestation). All three are stored in GHCR alongside the image and verify with `cosign verify` / `cosign verify-attestation` (see `SECURITY.md`). Helm chart signing is coming next.
+
 ## [0.4.8] - 2026-07-27
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Released container images are now signed, with an SBOM and SLSA build provenance.** The release workflow signs the pushed image keylessly with cosign (GitHub OIDC + sigstore, no key to manage), attaches a syft-generated SPDX SBOM as a cosign attestation, and attaches SLSA build provenance (`actions/attest-build-provenance`, also pushed to the registry as an OCI attestation). All three are stored in GHCR alongside the image and verify with `cosign verify` / `cosign verify-attestation` (see `SECURITY.md`). Helm chart signing is coming next.
+- **Released container images are now signed, with an SBOM and SLSA build provenance.** The release workflow signs the pushed image keylessly with cosign (GitHub OIDC + sigstore, no key to manage), attaches a syft-generated SPDX SBOM as a cosign attestation, and attaches SLSA build provenance (`actions/attest-build-provenance`, also pushed to the registry as an OCI attestation). All three are stored in GHCR alongside the image and verify with `cosign verify` / `cosign verify-attestation` (see `SECURITY.md`).
+- **The Helm chart is now also published as a signed OCI artifact** at `ghcr.io/tight-line/charts/ballast` (additive; the existing GitHub Pages `helm repo add` URL keeps working). The chart is keylessly cosign-signed with SLSA build provenance, so consumers can `helm pull oci://ghcr.io/tight-line/charts/ballast` and `cosign verify` it.
 
 ## [0.4.8] - 2026-07-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Released container images are now signed, with an SBOM and SLSA build provenance.** The release workflow signs the pushed image keylessly with cosign (GitHub OIDC + sigstore, no key to manage), attaches a syft-generated SPDX SBOM as a cosign attestation, and attaches SLSA build provenance (`actions/attest-build-provenance`, also pushed to the registry as an OCI attestation). All three are stored in GHCR alongside the image and verify with `cosign verify` / `cosign verify-attestation` (see `SECURITY.md`).
 - **The Helm chart is now also published as a signed OCI artifact** at `ghcr.io/tight-line/charts/ballast` (additive; the existing GitHub Pages `helm repo add` URL keeps working). The chart is keylessly cosign-signed with SLSA build provenance, so consumers can `helm pull oci://ghcr.io/tight-line/charts/ballast` and `cosign verify` it.
 
+### Changed
+
+- **Release image build now cross-compiles instead of emulating.** The `Dockerfile` builder stage runs on the native runner architecture (`--platform=$BUILDPLATFORM`) and cross-compiles the Go binary for the target arch, so the `linux/arm64` image no longer builds under slow QEMU emulation. The release workflow's separate amd64-first build was removed in favor of a single multi-arch build-push-sign, which also means the published `:latest`/`:<tag>` never briefly point at an unsigned image.
+
 ## [0.4.8] - 2026-07-27
 
 ### Security

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-# Build stage
-FROM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
+# Build stage. --platform=$BUILDPLATFORM keeps the Go toolchain on the native
+# runner architecture and cross-compiles for $TARGETARCH (see GOARCH below), so
+# an arm64 build doesn't run the whole builder under slow QEMU emulation.
+FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:3aff6657219a4d9c14e27fb1d8976c49c29fddb70ba835014f477e1c70636647 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG VERSION=dev

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -78,9 +78,10 @@ via the process above.
 ### Published artifacts
 
 - [x] Keyless (cosign/OIDC) signature for the released **container image**
-- [ ] Keyless signature for the **Helm chart** (in progress)
-- [x] SLSA build-provenance attestation for the released image (OCI + GitHub)
-- [x] Software Bill of Materials (SBOM) attached as an attestation
+- [x] Keyless signature for the **Helm chart**, published as an OCI artifact to
+      `ghcr.io/tight-line/charts/ballast` (the GitHub Pages Helm repo still works too)
+- [x] SLSA build-provenance attestation for the released image and chart (OCI + GitHub)
+- [x] Software Bill of Materials (SBOM) attached to the image as an attestation
 
 Verify a released image (all keyless, no public key needed):
 
@@ -96,6 +97,17 @@ cosign verify "$IMAGE" \
 cosign verify-attestation "$IMAGE" --type spdxjson \
   --certificate-identity-regexp "$IDENTITY" \
   --certificate-oidc-issuer "$ISSUER"
+```
+
+The Helm chart is signed the same way (same `$IDENTITY` / `$ISSUER`):
+
+```bash
+cosign verify ghcr.io/tight-line/charts/ballast:0.4.8 \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+
+# pull the signed chart via OCI
+helm pull oci://ghcr.io/tight-line/charts/ballast --version 0.4.8
 ```
 
 ### Runtime

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -77,9 +77,26 @@ via the process above.
 
 ### Published artifacts
 
-- [ ] Keyless (cosign/OIDC) signatures for the container image and Helm chart
-- [ ] SLSA build-provenance attestation for released images
-- [ ] Software Bill of Materials (SBOM) generated and attached as an attestation
+- [x] Keyless (cosign/OIDC) signature for the released **container image**
+- [ ] Keyless signature for the **Helm chart** (in progress)
+- [x] SLSA build-provenance attestation for the released image (OCI + GitHub)
+- [x] Software Bill of Materials (SBOM) attached as an attestation
+
+Verify a released image (all keyless, no public key needed):
+
+```bash
+IMAGE=ghcr.io/tight-line/ballast:v0.4.8   # use the tag you pulled
+IDENTITY='^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v'
+ISSUER=https://token.actions.githubusercontent.com
+
+cosign verify "$IMAGE" \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+
+cosign verify-attestation "$IMAGE" --type spdxjson \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+```
 
 ### Runtime
 


### PR DESCRIPTION
Workstream D (keyless signing + provenance for both released artifacts) plus a build-pipeline fix that fell out of reviewing it.

## Signing (image + chart)

- **Image** (`ghcr.io/tight-line/ballast`): cosign signature + syft SBOM (`cosign attest --type spdxjson`) + SLSA provenance (`attest-build-provenance`, `push-to-registry`).
- **Chart** (`ghcr.io/tight-line/charts/ballast`): now also published as an OCI artifact (additive; the GitHub Pages `helm repo add` URL is unchanged), cosign-signed with SLSA provenance.

All keyless (GitHub OIDC + sigstore), no keys, zero cost. Verify commands in `SECURITY.md`.

## Build: cross-compile arm64, single signed multi-arch push

- **`Dockerfile`**: the builder stage now runs on the native runner arch (`--platform=$BUILDPLATFORM`) and cross-compiles the Go binary for `$TARGETARCH`. The `linux/arm64` image no longer builds under QEMU emulation. **Verified locally**: buildkit cross-compiles (stage label `linux/…->…`), each `go build` ~25s, no emulation, vs the previous ~13 min for arm64.
- **`release-image`**: with arm64 now cheap, the amd64-first + multi-arch two-step collapses into a **single multi-arch build → push → sign**. Bonus: the published `:latest`/`:<tag>` are now set exactly once, by the build that gets signed, so they never briefly point at an unsigned amd64-only image (a gap the two-step had).

## Plumbing

- `id-token`/`attestations` write on both release jobs; `packages: write` + GHCR login on `release-chart`.
- Block allowlists extended with the sigstore trio, `api.github.com`, `ghcr.io`/`pkg-containers`, and GitHub release-asset hosts.
- New actions pinned to SHAs: `cosign-installer` v3.10.1, `sbom-action` v0.24.0, `attest-build-provenance` v3.2.0.

## Validation

- The `Dockerfile` change **is** PR-validated: `pr-images` builds multi-arch on this PR, so CI proves the cross-compile works and is fast.
- The signing steps are **not** PR-testable (`release.yml` is tag-only); the next tagged release is their first run. Low risk: standard actions, sigstore egress + OIDC already proven in block mode by the Scorecard job, and signing runs after the push so it can't block publishing.

## Sets up workstream F

The OCI signatures + attestations are what an admission controller verifies, so F can require them at admission time.