### PR TITLE
Fix release signing: SBOM egress + chart OCI push error handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
             *.githubapp.com:443
             release-assets.githubusercontent.com:443
             objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
             fulcio.sigstore.dev:443
             rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
@@ -205,12 +206,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}
         run: |
+          set -euo pipefail
           owner="${GITHUB_REPOSITORY_OWNER,,}"
           echo "$GH_TOKEN" | helm registry login ghcr.io -u "$ACTOR" --password-stdin
           helm package charts/ballast --destination .cr-oci
           chart_tgz="$(ls .cr-oci/ballast-*.tgz)"
+          # pipefail makes a failed `helm push` fail this step (instead of the
+          # pipe to tee masking it and leaving an empty digest for cosign).
           helm push "$chart_tgz" "oci://ghcr.io/${owner}/charts" 2>&1 | tee push.log
           digest="$(grep -oiE 'sha256:[0-9a-f]{64}' push.log | head -1)"
+          if [ -z "$digest" ]; then
+            echo "::error::could not determine pushed chart digest"; cat push.log; exit 1
+          fi
           echo "ref=ghcr.io/${owner}/charts/ballast" >> "$GITHUB_OUTPUT"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Release image SBOM + SLSA provenance attestations now publish.** The syft/SBOM step in the release workflow was blocked by harden-runner because `raw.githubusercontent.com` (used by `anchore/sbom-action` to fetch syft) was missing from the block allowlist; it has been added. 0.4.9 signed the image but skipped the SBOM/provenance because of this.
+- **Chart OCI publish now fails loudly instead of masking errors.** The OCI `helm push` was piped through `tee`, so a failed push was swallowed (exit 0) and surfaced later as a confusing empty-digest `cosign` error; added `set -o pipefail` and a digest guard so a push failure fails the step directly. (First-time creation of the `ghcr.io/tight-line/charts/ballast` package also requires a one-time GHCR permission/link step, see the notes on that release.)
+
 ## [0.4.9] - 2026-07-27
 
 ### Security
 
-- **Released container images are now signed, with an SBOM and SLSA build provenance.** The release workflow signs the pushed image keylessly with cosign (GitHub OIDC + sigstore, no key to manage), attaches a syft-generated SPDX SBOM as a cosign attestation, and attaches SLSA build provenance (`actions/attest-build-provenance`, also pushed to the registry as an OCI attestation). All three are stored in GHCR alongside the image and verify with `cosign verify` / `cosign verify-attestation` (see `SECURITY.md`).
-- **The Helm chart is now also published as a signed OCI artifact** at `ghcr.io/tight-line/charts/ballast` (additive; the existing GitHub Pages `helm repo add` URL keeps working). The chart is keylessly cosign-signed with SLSA build provenance, so consumers can `helm pull oci://ghcr.io/tight-line/charts/ballast` and `cosign verify` it.
+- **Released container images are now cosign-signed** (keyless via GitHub OIDC + sigstore, no key to manage), verifiable with `cosign verify` (see `SECURITY.md`). The accompanying SBOM and SLSA-provenance attestations, and the signed OCI Helm chart, were intended for this release but did not publish (a CI egress gap and a GHCR package-permission issue); both are addressed under [Unreleased].
 
 ### Changed
 


### PR DESCRIPTION
Fixes the two signing failures from the v0.4.9 release. **Image signing itself worked** (`cosign sign` succeeded); these are the two downstream steps that didn't.

## 1. Image SBOM step (blocked egress)

`Generate SBOM` failed with:
```
getaddrinfo EAI_AGAIN raw.githubusercontent.com
```
harden-runner (block mode) was denying `raw.githubusercontent.com`, which `anchore/sbom-action` needs to fetch syft. The allowlist had `release-assets`/`objects` but not `raw`. **Fix:** added `raw.githubusercontent.com:443` to the `release-image` allowlist. (Block mode doing its job, catching a real missing endpoint.)

## 2. Chart OCI push (masked failure + real 403)

`helm push` of the OCI chart actually failed:
```
PUT .../charts/ballast/manifests/0.4.9: 403 denied: permission_denied: write_package
```
but the `| tee` pipe swallowed the non-zero exit, so the step "passed" with an empty digest, and `cosign sign` then failed on `ghcr.io/tight-line/charts/ballast@`. **Fix:** `set -o pipefail` + a digest guard, so a failed push fails the step directly with the real error.

### ⚠️ The 403 also needs an org-side action (not code)

The image pushes fine because `ghcr.io/tight-line/ballast` already exists and is linked to the repo. `ghcr.io/tight-line/charts/ballast` is a **brand-new package**, and the repo's `GITHUB_TOKEN` was denied permission to create it. This code change makes the failure legible but won't make the push succeed on its own, the package needs a one-time creation + repo link (details in the PR discussion / follow-up).

## CHANGELOG

Corrected the just-released `[0.4.9]` entry: it claimed SBOM + provenance + signed OCI chart, but 0.4.9 only signed the image. Moved those to `[Unreleased]`. Flagging this since it edits a released entry, revert that part if you'd rather leave the record as-is.

## Validation

Same tag-only caveat: `release.yml` isn't exercised on this PR. Once this merges **and** the GHCR package permission is sorted, the next release should produce: signed image + SBOM + provenance, and signed OCI chart + provenance.