### PR TITLE
Attest image SBOM via referrers so it verifies with the standard commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,11 +106,17 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
 
-      - name: Attest SBOM (keyless)
-        env:
-          IMAGE: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast
-          DIGEST: ${{ steps.build.outputs.digest }}
-        run: cosign attest --yes --predicate sbom.spdx.json --type spdxjson "${IMAGE}@${DIGEST}"
+      # Attest the SBOM via actions/attest-sbom so it lands in the OCI referrers
+      # store, the same place actions/attest-build-provenance writes, rather than
+      # the legacy cosign `.att` tag. Keeps SBOM + provenance discoverable by the
+      # same `cosign verify-attestation` / `gh attestation verify` commands.
+      - name: Attest SBOM
+        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        with:
+          subject-name: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast
+          subject-digest: ${{ steps.build.outputs.digest }}
+          sbom-path: sbom.spdx.json
+          push-to-registry: true
 
       - name: Attest SLSA build provenance
         uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Image SBOM attestation now verifies with the standard commands.** The SBOM is attached via `actions/attest-sbom` (OCI referrers store) instead of `cosign attest`, so it lives alongside the SLSA provenance and is found by `cosign verify-attestation` / `gh attestation verify`. Previously it landed in the legacy cosign `.att` tag, which `cosign verify-attestation` (reading referrers) could not see, so the documented SBOM-verify command failed even though the SBOM was attached.
+
 ## [0.4.10] - 2026-07-27
 
 ### Fixed


### PR DESCRIPTION
Follow-up polish on workstream D, verified against the actual v0.4.10 release.

## What v0.4.10 proved (all green)

- Image signature: **verified** ✅
- Chart signature: **verified** ✅
- Image SLSA provenance: **verified** ✅ (`cosign verify-attestation --type slsaprovenance1` and `gh attestation verify`)
- Image SBOM: **attached but not discoverable** by `cosign verify-attestation`

## The inconsistency

`actions/attest-build-provenance` writes to the **OCI referrers** store; my SBOM used `cosign attest`, which writes to the **legacy `.att` tag**. `cosign verify-attestation` reads referrers, so it found the provenance and missed the SBOM, even though `cosign download attestation` shows the SBOM is attached (`https://spdx.dev/Document`). The `SECURITY.md` SBOM-verify command therefore didn't work.

## Fix

Attest the SBOM with **`actions/attest-sbom`** (`push-to-registry: true`) instead of `cosign attest`, so SBOM and provenance share the referrers store and both verify with the same `cosign verify-attestation` / `gh attestation verify` commands. `anchore/sbom-action` still generates the SPDX SBOM; only the attest mechanism changes. No egress/permission changes (referrers use the sigstore + `api.github.com` hosts already allowed).

## Validation

Tag-only, so it validates on the next release. After that, `cosign verify-attestation` should find both the SBOM and the provenance on the image, matching the `SECURITY.md` commands.