### PR TITLE
OCI-only chart distribution + admission verification (workstream F)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,7 +129,7 @@ jobs:
     name: Package and publish Helm chart
     runs-on: ubuntu-latest
     permissions:
-      contents: write       # chart-releaser: GitHub release + gh-pages
+      contents: write       # create the per-tag GitHub release (gh CLI)
       packages: write       # push the chart as an OCI artifact to GHCR
       id-token: write       # keyless cosign signing + provenance (GitHub OIDC)
       attestations: write   # actions/attest-build-provenance
@@ -155,13 +155,6 @@ jobs:
             tuf-repo-cdn.sigstore.dev:443
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - name: Configure Git
-        run: |
-          git config user.name "$GITHUB_ACTOR"
-          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
         uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
@@ -185,17 +178,13 @@ jobs:
           mkdir -p charts/ballast/crds
           cp config/crd/bases/*.yaml charts/ballast/crds/
 
-      - name: Run chart-releaser
-        uses: helm/chart-releaser-action@cae68fefc6b5f367a0275617c9f83181ba54714f # v1.7.0
-        with:
-          skip_existing: true
-        env:
-          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
-      # Also publish the chart as a signed OCI artifact to GHCR, alongside the
-      # GitHub Pages repo above (additive; the `helm repo add` URL still works).
-      # Consumers can `helm pull oci://ghcr.io/<owner>/charts/ballast` and
-      # `cosign verify`. Keyless via GitHub OIDC + sigstore.
+      # Publish the chart as a signed OCI artifact to GHCR. This is now the only
+      # published Helm repo: the former GitHub Pages repo
+      # (`helm repo add ballast https://tight-line.github.io/ballast`) is frozen
+      # at its last chart-releaser version and no longer receives new releases
+      # (see the breaking-change note in CHANGELOG). Consumers install via
+      # `helm install oci://ghcr.io/<owner>/charts/ballast` and can `cosign
+      # verify` the chart. Keyless via GitHub OIDC + sigstore.
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
         with:
@@ -226,6 +215,7 @@ jobs:
           fi
           echo "ref=ghcr.io/${owner}/charts/ballast" >> "$GITHUB_OUTPUT"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
+          echo "tgz=${chart_tgz}" >> "$GITHUB_OUTPUT"
 
       - name: Sign chart (keyless)
         env:
@@ -239,3 +229,26 @@ jobs:
           subject-name: ${{ steps.oci.outputs.ref }}
           subject-digest: ${{ steps.oci.outputs.digest }}
           push-to-registry: true
+
+      # chart-releaser used to create the per-tag GitHub release; recreate it
+      # with the gh CLI (already on the runner, no third-party action) so each
+      # tag still gets a release with auto-generated notes and the packaged
+      # chart attached as a convenience download. The signed OCI chart above is
+      # the canonical artifact; this asset is a courtesy copy.
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TGZ: ${{ steps.oci.outputs.tgz }}
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF#refs/tags/}"
+          # Idempotent: re-running an existing tag must not fail the job.
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "release $tag already exists; uploading chart asset"
+            gh release upload "$tag" "$TGZ" --repo "$GITHUB_REPOSITORY" --clobber
+          else
+            gh release create "$tag" "$TGZ" \
+              --repo "$GITHUB_REPOSITORY" \
+              --title "$tag" \
+              --generate-notes
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,10 +272,11 @@ Run `scripts/make-tag <version>` (e.g. `scripts/make-tag 0.1.0`) to cut a releas
 4. Commits and tags `v<version>`
 
 Then `git push origin main v<version>` triggers `release.yml`, which:
-- Builds and pushes `ghcr.io/tight-line/ballast:v<version>` and `:latest` (multi-arch: amd64 + arm64)
-- Runs `helm dependency update` then `helm/chart-releaser-action` to package `ballast-<version>.tgz`, upload it as a GitHub Release asset, and update `index.yaml` on the `gh-pages` branch
+- Builds and pushes `ghcr.io/tight-line/ballast:v<version>` and `:latest` (multi-arch: amd64 + arm64), then cosign-signs the image and attaches an SBOM + SLSA provenance
+- Runs `helm dependency update`, packages the chart, and pushes it as a signed OCI artifact to `ghcr.io/tight-line/charts/ballast` (cosign signature + SLSA provenance)
+- Creates the GitHub Release for the tag via the `gh` CLI, attaching the packaged `ballast-<version>.tgz` as a convenience asset
 
-The Helm repo (`https://tight-line.github.io/ballast`) is served from the `gh-pages` branch; GitHub Pages must be enabled on the repository pointing to that branch.
+The signed OCI chart at `ghcr.io/tight-line/charts/ballast` is the sole published Helm repo. The old GitHub Pages repo (`https://tight-line.github.io/ballast`, served from `gh-pages`) is **frozen**: `chart-releaser` was removed, so no new versions publish there, but the existing `gh-pages` `index.yaml` is left in place so already-published versions keep resolving for existing `helm repo add` users.
 
 ### PR image workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING: the Helm chart is now distributed only as a signed OCI artifact.** Installs and upgrades must use `helm install ballast oci://ghcr.io/tight-line/charts/ballast` (see the README). The release workflow no longer runs `chart-releaser`, so the GitHub Pages Helm repo (`helm repo add ballast https://tight-line.github.io/ballast`) receives no new versions. That repo is **frozen, not deleted**: the existing `gh-pages` `index.yaml` is left in place, so already-published versions keep resolving for current `helm repo add` users; only new releases require the OCI flow. Migrate your install to `oci://…` when you next upgrade. The OCI chart has been published (and cosign-signed) alongside the Pages repo since 0.4.9, so the artifact itself is unchanged; only the default/primary distribution path moves.
+- **Per-tag GitHub Releases are now created by the `gh` CLI** instead of `chart-releaser`. Each release is named for its tag (`v<version>`) and still has auto-generated notes plus the packaged `ballast-<version>.tgz` attached as a convenience download; the signed OCI chart remains the canonical artifact.
+
+### Added
+
+- **Admission-time image-verification examples** under [`examples/admission/`](examples/admission/README.md) for both Kyverno and sigstore policy-controller. They are opt-in (the chart does not install them) and configure the cluster to admit only `ghcr.io/tight-line/ballast` images carrying a valid keyless cosign signature from the release workflow.
+- **README "Verifying the release" and "Older releases" sections**: cosign verify commands for the image and chart (run them before installing), and a pointer to where old versions live (the frozen Pages repo) versus new ones (OCI), with the full list on the GitHub Releases page.
+
+### Fixed
+
+- **Corrected the SBOM verification command in `SECURITY.md`.** It used `--type spdxjson`, which does not match the versioned SPDX predicate type that syft emits; the correct invocation is `--type https://spdx.dev/Document/v2.3`. Also added the image SLSA-provenance verify command and a `gh attestation verify` alternative.
+
 ## [0.4.12] - 2026-07-28
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -56,17 +56,43 @@ Pod eviction for cluster rebalancing is handled by [Kubernetes Descheduler](http
 cert-manager must already be installed in the cluster (Ballast does not install it):
 
 ```bash
-helm repo add ballast https://tight-line.github.io/ballast
-helm repo update
-
-helm install ballast ballast/ballast \
+helm install ballast oci://ghcr.io/tight-line/charts/ballast \
   --namespace ballast-system \
   --create-namespace
 ```
 
+This pulls the latest signed chart from the GitHub Container Registry. To pin a version, add `--version <X.Y.Z>` (the [Releases page](https://github.com/Tight-Line/ballast/releases) lists every version). For supply-chain-sensitive clusters, [verify the chart's signature](#verifying-the-release) before installing, and consider enforcing that verification at admission time ([`examples/admission`](examples/admission/README.md)).
+
 The chart ships with a sensible default for `ballastConfig.identityLabels` (`app.kubernetes.io/name` + `app.kubernetes.io/component`). Read the section below before overriding it — the choice has cluster-wide consequences.
 
-Upgrades are `helm upgrade --install` with no extra steps. CRDs are kept in sync automatically: Helm itself never upgrades the `crds/` directory, so the chart runs a pre-install/pre-upgrade hook Job (`ballastd apply-crds`) that server-side-applies the CRD manifests baked into the operator image. Set `crds.upgradeHook.enabled: false` to opt out if external tooling manages CRDs; you are then responsible for applying `config/crd/bases/` on every upgrade.
+Upgrades are `helm upgrade --install ballast oci://ghcr.io/tight-line/charts/ballast` with no extra steps. CRDs are kept in sync automatically: Helm itself never upgrades the `crds/` directory, so the chart runs a pre-install/pre-upgrade hook Job (`ballastd apply-crds`) that server-side-applies the CRD manifests baked into the operator image. Set `crds.upgradeHook.enabled: false` to opt out if external tooling manages CRDs; you are then responsible for applying `config/crd/bases/` on every upgrade.
+
+## Verifying the release
+
+Both the container image (`ghcr.io/tight-line/ballast`) and the Helm chart (`ghcr.io/tight-line/charts/ballast`) are keyless-signed with [cosign](https://docs.sigstore.dev/) via GitHub OIDC and the public sigstore infrastructure. There is no public key to manage; verification checks that the artifact was signed by Ballast's release workflow.
+
+```bash
+IDENTITY='^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v'
+ISSUER=https://token.actions.githubusercontent.com
+
+# container image
+cosign verify ghcr.io/tight-line/ballast:<tag> \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+
+# Helm chart
+cosign verify ghcr.io/tight-line/charts/ballast:<version> \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+```
+
+The image also carries a SLSA build-provenance attestation and an SBOM; [SECURITY.md](SECURITY.md#published-artifacts) has the full set of verification commands. To make the cluster admit only images that pass this check, see [`examples/admission`](examples/admission/README.md).
+
+## Older releases
+
+Ballast is distributed as signed OCI artifacts from the GitHub Container Registry: the operator image at `ghcr.io/tight-line/ballast` and the Helm chart at `ghcr.io/tight-line/charts/ballast`. Releases through v0.4.x were also published to a GitHub Pages Helm repo at `https://tight-line.github.io/ballast`. That repo is now **frozen**: existing `helm repo add` users and already-published versions keep resolving, but new versions ship only via the OCI chart above, so migrate to the `helm install oci://…` flow when you upgrade.
+
+Every release, with its notes and the packaged chart attached, is on the [Releases page](https://github.com/Tight-Line/ballast/releases).
 
 ## WorkloadProfile Identity
 
@@ -400,7 +426,7 @@ This catch-all policy applies to every opted-in pod in the cluster. Key design d
 The default above is one entry in a catalog of presets — Helm values overlays under [`charts/ballast/presets/`](charts/ballast/presets/README.md) that retune the policy for a particular operating profile. `homogeneous-large-fleet` is built into `values.yaml`; `local-testing` is a fast-cycle overlay for kind clusters. Select one at install time with `-f`:
 
 ```bash
-helm install ballast ballast/ballast -n ballast-system --create-namespace \
+helm install ballast oci://ghcr.io/tight-line/charts/ballast -n ballast-system --create-namespace \
   -f charts/ballast/presets/local-testing.yaml
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -79,46 +79,65 @@ via the process above.
 
 - [x] Keyless (cosign/OIDC) signature for the released **container image**
 - [x] Keyless signature for the **Helm chart**, published as an OCI artifact to
-      `ghcr.io/tight-line/charts/ballast` (the GitHub Pages Helm repo still works too)
+      `ghcr.io/tight-line/charts/ballast` (now the sole published Helm repo; the
+      former GitHub Pages repo is frozen, see the README's "Older releases")
 - [x] SLSA build-provenance attestation for the released image and chart (OCI + GitHub)
 - [x] Software Bill of Materials (SBOM) attached to the image as an attestation
 
 Verify a released image (all keyless, no public key needed):
 
 ```bash
-IMAGE=ghcr.io/tight-line/ballast:v0.4.8   # use the tag you pulled
+IMAGE=ghcr.io/tight-line/ballast:<tag>   # use the tag you pulled
 IDENTITY='^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v'
 ISSUER=https://token.actions.githubusercontent.com
 
+# signature
 cosign verify "$IMAGE" \
   --certificate-identity-regexp "$IDENTITY" \
   --certificate-oidc-issuer "$ISSUER"
 
-cosign verify-attestation "$IMAGE" --type spdxjson \
+# SLSA build provenance
+cosign verify-attestation "$IMAGE" --type slsaprovenance1 \
   --certificate-identity-regexp "$IDENTITY" \
   --certificate-oidc-issuer "$ISSUER"
+
+# SBOM (syft emits a versioned SPDX predicate type; the `spdxjson` shorthand
+# does NOT match it)
+cosign verify-attestation "$IMAGE" --type https://spdx.dev/Document/v2.3 \
+  --certificate-identity-regexp "$IDENTITY" \
+  --certificate-oidc-issuer "$ISSUER"
+```
+
+Or verify the image's attestations with the GitHub CLI, which resolves the
+identity for you:
+
+```bash
+gh attestation verify oci://ghcr.io/tight-line/ballast:<tag> --repo Tight-Line/ballast
 ```
 
 The Helm chart is signed the same way (same `$IDENTITY` / `$ISSUER`):
 
 ```bash
-cosign verify ghcr.io/tight-line/charts/ballast:0.4.8 \
+cosign verify ghcr.io/tight-line/charts/ballast:<version> \
   --certificate-identity-regexp "$IDENTITY" \
   --certificate-oidc-issuer "$ISSUER"
 
-# pull the signed chart via OCI
-helm pull oci://ghcr.io/tight-line/charts/ballast --version 0.4.8
+# install (or pull) the signed chart via OCI
+helm install ballast oci://ghcr.io/tight-line/charts/ballast --version <version>
 ```
 
 ### Runtime
 
 - [x] Distroless, non-root runtime image (`USER 65532`, no shell)
-- [ ] Least-privilege review of the operator's RBAC (scoped to the verbs and
-      resources it actually needs)
-- [ ] Explicit hardened pod `securityContext` in the Helm chart
-      (`readOnlyRootFilesystem`, drop all capabilities, `seccompProfile: RuntimeDefault`)
-- [ ] Deployment guidance for admission-time verification (policy-controller or
-      Kyverno) so clusters admit only signed, provenanced images
+- [x] Least-privilege review of the operator's RBAC (scoped to the verbs and
+      resources it actually uses; ConfigMap access narrowed to the operator's
+      own namespace rather than cluster-wide)
+- [x] Explicit hardened pod `securityContext` in the Helm chart
+      (`readOnlyRootFilesystem`, drop all capabilities, `seccompProfile: RuntimeDefault`,
+      `runAsNonRoot`, `allowPrivilegeEscalation: false`)
+- [x] Deployment guidance for admission-time verification (Kyverno and
+      policy-controller examples in [`examples/admission`](examples/admission/README.md))
+      so clusters admit only signed, provenanced images
 
 ### Repository controls
 

--- a/examples/admission/README.md
+++ b/examples/admission/README.md
@@ -1,0 +1,58 @@
+# Admission-time image verification (opt-in)
+
+Ballast's release container image is keyless-signed with cosign (GitHub OIDC +
+the public sigstore infrastructure), and carries SLSA build-provenance and an
+SBOM as attestations. You can verify a pulled image by hand with `cosign`
+(see the "Verifying the release" section of the top-level [README](../../README.md)
+and [SECURITY.md](../../SECURITY.md)).
+
+These examples go one step further: they make the **cluster** enforce that
+verification at admission time, so an image that isn't validly signed by the
+Ballast release workflow can't be scheduled at all.
+
+## This is opt-in, on purpose
+
+The Ballast Helm chart does **not** install any of this. Admission-time
+verification is a cluster-operator decision, not a workload's:
+
+- It requires an admission engine (Kyverno or policy-controller) to already be
+  running in the cluster.
+- Its blast radius is cluster-wide: a policy can block pods well beyond Ballast,
+  and a misconfigured one can lock you out of your own cluster.
+- Admission webhooks are cluster-critical infrastructure; a workload chart
+  shouldn't quietly reinstall or reconfigure them.
+
+So the chart stays out of it, and these manifests are here for you to review,
+scope, and apply deliberately.
+
+## Choose an engine
+
+Both are free, open-source, and verify the same thing; pick whichever your
+cluster already runs (or prefers).
+
+| Engine | File | Notes |
+|---|---|---|
+| **Kyverno** | [`kyverno/verify-ballast-image-keyless.yaml`](kyverno/verify-ballast-image-keyless.yaml) | CNCF project, general-purpose policy engine. Most clusters that run any policy engine run this one. |
+| **sigstore policy-controller** | [`policy-controller/ballast-keyless.yaml`](policy-controller/ballast-keyless.yaml) | Purpose-built for cosign/keyless verification; narrower scope. Requires per-namespace opt-in labels. |
+
+Both examples pin the exact signing identity of the Ballast release workflow:
+
+- **Subject** (regexp): `^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v`
+- **Issuer**: `https://token.actions.githubusercontent.com`
+- **Image**: `ghcr.io/tight-line/ballast:*`
+
+Both are fail-closed by default (block on a missing or mismatched signature).
+Each file's header comments cover its prerequisites and how to extend it to also
+require the SLSA provenance attestation.
+
+## Roll out safely
+
+1. Install your chosen engine and confirm its webhook is healthy.
+2. Apply the policy to a **non-production** namespace first. For
+   policy-controller, label that namespace:
+   `kubectl label namespace <ns> policy.sigstore.dev/include=true`.
+3. Confirm fail-closed behavior: try to run an **unsigned** image (or a
+   deliberately wrong tag) and check that admission is rejected. Read the
+   rejection message with `kubectl describe` on the blocked Pod/ReplicaSet.
+4. Only then widen the policy to the namespaces where Ballast (and anything else
+   you want gated) runs.

--- a/examples/admission/kyverno/verify-ballast-image-keyless.yaml
+++ b/examples/admission/kyverno/verify-ballast-image-keyless.yaml
@@ -1,0 +1,70 @@
+# Kyverno ClusterPolicy: admit ghcr.io/tight-line/ballast only if it carries a
+# valid keyless cosign signature from the Ballast release workflow.
+#
+# OPT-IN EXAMPLE. The Ballast Helm chart does NOT install this. Applying a
+# cluster-wide image-verification policy is a cluster operator's decision, not a
+# workload's: it requires Kyverno to already be running, it can block admission
+# cluster-wide, and a misconfigured policy can lock you out of your own cluster.
+# Review it, scope it, and roll it out to a non-production namespace first.
+#
+# Prerequisites:
+#   - Kyverno installed (v1.11+; fields below are stable through the 1.18 line).
+#   - Cluster egress to the public sigstore services (Fulcio/Rekor) so the
+#     admission webhook can verify signatures.
+#
+# Verified against https://kyverno.io/docs/policy-types/cluster-policy/verify-images/sigstore/
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  name: verify-ballast-image-keyless
+  annotations:
+    policies.kyverno.io/title: Verify Ballast Image (Keyless Cosign)
+    policies.kyverno.io/category: Software Supply Chain Security
+    policies.kyverno.io/severity: high
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Requires ghcr.io/tight-line/ballast images to carry a valid keyless cosign
+      signature produced by the Ballast release.yml GitHub Actions workflow,
+      verified against the public Fulcio/Rekor sigstore instances.
+spec:
+  # Fail closed: if the Kyverno webhook itself is unreachable, block admission
+  # rather than letting an unverified image through.
+  webhookConfiguration:
+    failurePolicy: Fail
+    timeoutSeconds: 30
+  # Image verification is an admission-time check, not a background scan.
+  background: false
+  rules:
+    - name: verify-ballast-signature
+      match:
+        any:
+          - resources:
+              kinds:
+                - Pod
+      verifyImages:
+        # Colon-glob: matches tags of exactly this repository. A bare-prefix
+        # glob (ballast*) would also match sibling repos like ballast-foo.
+        - imageReferences:
+            - "ghcr.io/tight-line/ballast:*"
+          failureAction: Enforce   # block on missing/invalid signature (Audit = log only)
+          required: true           # every matching image must verify
+          mutateDigest: true       # pin the verified tag to its immutable digest
+          verifyDigest: true       # if the pod already pins a digest, it must be the signed one
+          attestors:
+            - count: 1
+              entries:
+                - keyless:
+                    # Use subjectRegExp (not subject) for a regexp identity.
+                    subjectRegExp: '^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v'
+                    issuer: "https://token.actions.githubusercontent.com"
+                    # rekor.url and a ctlog block are optional; omitting them
+                    # defaults to the public sigstore instances. Shown for clarity.
+                    rekor:
+                      url: https://rekor.sigstore.dev
+
+# To ALSO require the SLSA build-provenance attestation (this image publishes one
+# via actions/attest-build-provenance), add an `attestations:` list to the same
+# verifyImages[] entry, each with a `predicateType` (e.g.
+# https://slsa.dev/provenance/v1) and an `attestors` block reusing the same
+# keyless identity above. See
+# https://github.com/kyverno/website/blob/main/src/content/policies/other/verify-image-slsa/verify-image-slsa.md

--- a/examples/admission/policy-controller/ballast-keyless.yaml
+++ b/examples/admission/policy-controller/ballast-keyless.yaml
@@ -1,0 +1,49 @@
+# sigstore policy-controller ClusterImagePolicy: admit ghcr.io/tight-line/ballast
+# only if it carries a valid keyless cosign signature from the Ballast release
+# workflow.
+#
+# OPT-IN EXAMPLE. The Ballast Helm chart does NOT install this. Admission-time
+# image verification is a cluster operator's decision: it requires the
+# policy-controller webhook to already be running and can block admission, so
+# review, scope, and roll it out to a non-production namespace first.
+#
+# Prerequisites:
+#   - policy-controller installed (webhook running). See
+#     https://docs.sigstore.dev/policy-controller/installation/
+#   - Each namespace you want gated MUST opt in with the label:
+#       kubectl label namespace <ns> policy.sigstore.dev/include=true
+#     policy-controller ignores pods in unlabeled namespaces entirely.
+#   - Cluster egress to the public sigstore services (Fulcio/Rekor).
+#
+# Verified against https://github.com/sigstore/policy-controller/blob/main/docs/api-types/index.md (v1beta1)
+apiVersion: policy.sigstore.dev/v1beta1
+kind: ClusterImagePolicy
+metadata:
+  name: ballast-keyless
+spec:
+  # mode defaults to "enforce" (hard rejection). Set mode: warn only for a
+  # deliberate soft rollout.
+  images:
+    # Colon-glob: tags of exactly this repository. Add a second entry
+    # "ghcr.io/tight-line/ballast@sha256:**" if you expect digest-pinned pulls.
+    - glob: "ghcr.io/tight-line/ballast:*"
+  authorities:
+    - keyless:
+        # Public Fulcio. Optional when using the default embedded TUF root.
+        url: https://fulcio.sigstore.dev
+        identities:
+          - issuerRegExp: "^https://token\\.actions\\.githubusercontent\\.com$"
+            subjectRegExp: '^https://github\.com/Tight-Line/ballast/\.github/workflows/release\.yml@refs/tags/v'
+      # NOTE: this field is named `ctlog` but is typed as the Rekor transparency
+      # log (not certificate transparency). Omitting it defaults to public Rekor.
+      ctlog:
+        url: https://rekor.sigstore.dev
+
+# For a fail-closed CLUSTER posture (reject images that match NO policy at all),
+# set `no-match-policy: deny` in the `config-policy-controller` ConfigMap. That
+# is a cluster-wide setting, separate from this per-image policy.
+#
+# To ALSO require the SLSA build-provenance attestation, add an `attestations:`
+# list under this authorities[] entry (sibling to `keyless`), each with a
+# `predicateType`; policy-controller verifies it against the same identity after
+# the signature check succeeds.


### PR DESCRIPTION
Workstream **F** — the final supply-chain layer: make the signed OCI chart the primary (and only) published Helm repo, give users a verify-before-install path, and add opt-in admission-time enforcement.

> [!WARNING]
> **Breaking change to chart distribution.** The GitHub Pages Helm repo (`helm repo add ballast https://tight-line.github.io/ballast`) no longer receives new versions. It is **frozen, not deleted** — the existing `gh-pages` `index.yaml` stays in place so already-published versions keep resolving for current users. New installs/upgrades use `helm install oci://ghcr.io/tight-line/charts/ballast`. The OCI chart has been published and cosign-signed since 0.4.9, so only the primary distribution path moves; the artifact itself is unchanged.

## F1 — Verify before install (docs)

- **README** gains a **"Verifying the release"** section (cosign verify for the image and chart, run before installing) and an **"Older releases"** section (what changed, where old versions live — the frozen Pages repo — vs new ones on OCI, with the full list on the Releases page). Install/upgrade commands switch to `oci://`.
- **SECURITY.md**: fixes the SBOM verify command (`--type spdxjson` → `--type https://spdx.dev/Document/v2.3`, since syft emits a versioned predicate type), adds the SLSA-provenance verify + a `gh attestation verify` alternative, and checks the three **Runtime** posture boxes (least-privilege RBAC, hardened `securityContext`, admission guidance).

## F2 — Admission-time verification (opt-in examples)

New [`examples/admission/`](examples/admission/README.md) with policies for **both** engines that admit only `ghcr.io/tight-line/ballast` images carrying a valid keyless cosign signature from the release workflow:

- **Kyverno** `ClusterPolicy` (`kyverno.io/v1`, rule-level `failureAction: Enforce`, fail-closed webhook).
- **sigstore policy-controller** `ClusterImagePolicy` (`policy.sigstore.dev/v1beta1`, per-namespace opt-in label).

Both pin the exact signing identity (`subjectRegExp` + issuer) and use the `:*` colon-glob (not a bare prefix, which would also match sibling repos). **The chart does not install these** — admission enforcement is cluster-wide and cluster-critical, so it's a deliberate operator decision, not something a workload chart should impose. Syntax verified against current Kyverno and policy-controller docs.

## F3 — OCI-only release pipeline

`release.yml` (`release-chart` job):

- **Removed** `chart-releaser` (which published to gh-pages) and its `Configure Git` step.
- **Kept** the signed OCI push + cosign signature + SLSA provenance (unchanged).
- **Recreated** the per-tag GitHub Release with the `gh` CLI — no new third-party action (better for the supply-chain story). Auto-generated notes + the packaged `ballast-<version>.tgz` attached as a convenience asset. Idempotent on tag re-runs.

Releases are now named for their tag (`v<version>`) rather than `ballast-<version>`.

## Notes for review

- This is tag-only, so `release.yml` can't be exercised on this PR; the `gh release` step was written defensively (`set -euo pipefail`, existence check before create).
- The **RBAC** posture box checked in `SECURITY.md` is implemented by #84 (workstream E). Both are part of the same series and merge into the same release; I put all three runtime-box flips here to keep the checklist edits in one place.

## Validation

- `make lint` — clean (0 issues)
- `make test-coverage-check` — passed (no Go changes on this branch)
- Both admission manifests parse as valid Kubernetes YAML (correct apiVersion/kind)
- `release.yml` — valid YAML; step order and outputs (`ref`/`digest`/`tgz`) wired correctly