### PR TITLE
Fix release: stop SBOM action attaching to the GitHub release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,13 @@ jobs:
           image: ${{ steps.meta.outputs.IMAGE_PREFIX }}/ballast@${{ steps.build.outputs.digest }}
           format: spdx-json
           output-file: sbom.spdx.json
+          # Do not attach the SBOM as a GitHub release asset. It defaults to true
+          # and now finds the v<tag> release (created by the release-chart job) and
+          # tries to upload, which needs contents: write — this job is deliberately
+          # contents: read. The SBOM is attested into the OCI referrers store below
+          # (actions/attest-sbom) and kept as a workflow artifact, so the release
+          # asset would be redundant anyway.
+          upload-release-assets: false
 
       # Attest the SBOM via actions/attest-sbom so it lands in the OCI referrers
       # store, the same place actions/attest-build-provenance writes, rather than

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Corrected the SBOM verification command in `SECURITY.md`.** It used `--type spdxjson`, which does not match the versioned SPDX predicate type that syft emits; the correct invocation is `--type https://spdx.dev/Document/v2.3`. Also added the image SLSA-provenance verify command and a `gh attestation verify` alternative.
+- **Release: the image SBOM and SLSA-provenance attestations now publish again.** The `anchore/sbom-action` step defaults to attaching the SBOM as a GitHub release asset, which needs `contents: write`; the `release-image` job is intentionally `contents: read`. Once the release workflow began creating a release named for the git tag (`v<version>`), the action found it and failed trying to upload, which aborted the job before the `Attest SBOM` and `Attest SLSA build provenance` steps ran. Set `upload-release-assets: false` (the SBOM is already attested into the OCI registry and kept as a workflow artifact, so the release asset was redundant). v0.5.0's image shipped signed but without those two attestations; this restores them for the next release.
 
 ## [0.4.12] - 2026-07-28
 


### PR DESCRIPTION
## The bug

The first OCI-only release (**v0.5.0**, running the workstream-F workflow) failed in the `release-image` job:

```
--------------------- Attaching SBOMs to release: 'v0.5.0' ---------------------
Error: Resource not accessible by integration
```

`anchore/sbom-action` defaults to `upload-release-assets: true`, which attaches the generated SBOM as a **GitHub release asset** and needs `contents: write`. The `release-image` job is deliberately `contents: read` (least-privilege, workstream C).

### Why it only surfaced now

Under the old `chart-releaser` flow, the GitHub release was named `ballast-<version>`, which never matched the git tag `v<version>` — so `anchore/sbom-action` found no release for the tag and silently skipped the upload. The OCI-only workflow (#85) now creates a release named for the tag (`v<version>`), so the action finds it and tries to upload, hitting the permission wall.

### Impact on v0.5.0

The failing step aborted the job **before** the `Attest SBOM` and `Attest SLSA build provenance` steps. Verified state of what shipped:

| Artifact | Signed | SBOM | Provenance |
|---|---|---|---|
| image (`ghcr.io/tight-line/ballast:v0.5.0`) | ✅ | ❌ missing | ❌ missing |
| chart (`ghcr.io/tight-line/charts/ballast:0.5.0`) | ✅ | n/a | ✅ |

So v0.5.0's image is signed but missing the two attestations. **A re-release (v0.5.1) is needed** once this merges.

## The fix

Set `upload-release-assets: false` on the Generate SBOM step. The SBOM is already attested into the OCI referrers store (`actions/attest-sbom`, verifiable via `cosign verify-attestation` / `gh attestation verify`) and kept as a workflow artifact, so the release asset was redundant. This keeps `release-image` at `contents: read` rather than widening it to `contents: write` just to attach a duplicate.

## Validation

- `make lint` — clean
- `make test-coverage-check` — passed (no Go changes)
- `release.yml` — valid YAML

Tag-only workflow, so it can't be exercised on this PR; it gets its first real run on the v0.5.1 re-release after merge.